### PR TITLE
Subgraph redesign

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ simple-sds = { git = "https://github.com/jltsiren/simple-sds", branch = "main" }
 rusqlite = { version = "0.31", features = ["bundled"] }
 getopts = { version = "0.2" }
 flate2 = { version = "1.0" }
+rand = { version = "0.8", optional = true }
+
+[dev-dependencies]
+rand = "0.8"
 
 [[bin]]
 name = "gbz2db"

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -72,9 +72,9 @@ impl Config {
         opts.optflag("h", "help", "print this help");
         opts.optopt("", "sample", "sample name (default: no sample name)", "STR");
         opts.optopt("", "contig", "contig name (required for -o and -i)", "STR");
-        opts.optopt("o", "offset", "sequence offset (-o, -i, or -n is required)", "INT");
-        opts.optopt("i", "interval", "sequence interval (-o, -i, or -n is required)", "INT..INT");
-        opts.optopt("n", "node", "node identifier (-o, -i, or -n is required)", "INT");
+        opts.optopt("o", "offset", "sequence offset", "INT");
+        opts.optopt("i", "interval", "sequence interval", "INT..INT");
+        opts.optmulti("n", "node", "node identifier (may repeat)", "INT");
         let context_desc = format!("context length in bp (default: {})", Self::DEFAULT_CONTEXT);
         opts.optopt("", "context", &context_desc, "INT");
         opts.optflag("", "distinct", "output distinct haplotypes with weights");
@@ -83,8 +83,8 @@ impl Config {
         opts.optopt("", "format", "output format (gfa or json, default: gfa)", "STR");
         let matches = opts.parse(&args[1..]).map_err(|x| x.to_string())?;
 
+        let header = format!("Usage: {} [options] graph.gbz[.db]\n\nQuery type must be speficied using one of -o, -i, and -n.", program);
         if matches.opt_present("help") {
-            let header = format!("Usage: {} [options] graph.gbz[.db]", program);
             eprint!("{}", opts.usage(&header));
             process::exit(0);
         }
@@ -92,7 +92,6 @@ impl Config {
         let filename = if let Some(s) = matches.free.first() {
             s.clone()
         } else {
-            let header = format!("Usage: {} [options] graph.gbz[.db]", program);
             eprint!("{}", opts.usage(&header));
             process::exit(1);
         };
@@ -164,14 +163,15 @@ impl Config {
             let interval = Self::parse_interval(&s)?;
             let query = SubgraphQuery::path_interval(&path_name.unwrap(), interval, context, output);
             Ok(query)
-        }
-        else if let Some(s) = matches.opt_str("node") {
-            let node = Self::parse_integer(&s, "node")?;
-            let query = SubgraphQuery::node(node, context, output);
+        } else {
+            let node_strings = matches.opt_strs("node");
+            let mut nodes = Vec::with_capacity(node_strings.len());
+            for node in node_strings {
+                let id = Self::parse_integer(&node, "node")?;
+                nodes.push(id);
+            }
+            let query = SubgraphQuery::nodes(nodes, context, output);
             Ok(query)
-        }
-        else {
-            unreachable!();
         }
     }
 }

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -20,15 +20,16 @@ fn main() -> Result<(), String> {
 
     // Determine the type of the input file and extract the subgraph accordingly.
     let use_gbz = GBZ::is_gbz(&config.filename);
-    let subgraph = if use_gbz {
+    let mut subgraph = Subgraph::new();
+    if use_gbz {
         let graph: GBZ = serialize::load_from(&config.filename).map_err(|x| x.to_string())?;
         let path_index = PathIndex::new(&graph, GBZBase::INDEX_INTERVAL, false)?;
-        Subgraph::from_gbz(&graph, Some(&path_index), &config.query)?
+        subgraph.from_gbz(&graph, Some(&path_index), &config.query)?;
     } else {
         let database = GBZBase::open(&config.filename)?;
         let mut graph = GraphInterface::new(&database)?;
-        Subgraph::from_db(&mut graph, &config.query)?
-    };
+        subgraph.from_db(&mut graph, &config.query)?;
+    }
 
     // Write the output.
     let mut output = io::stdout();

--- a/src/db.rs
+++ b/src/db.rs
@@ -1103,6 +1103,18 @@ impl GBZRecord {
         self.edges.iter().filter(|x| x.node != gbwt::ENDMARKER).copied()
     }
 
+    /// Returns the slice of edges stored in the record.
+    ///
+    /// Each edge is a pair consisting of a destination node handle and a offset in the corresponding GBWT record.
+    /// The edges are sorted by destination node.
+    /// This slice does not list the possible edge to [`gbwt::ENDMARKER`], as it only exists for technical purposes.
+    pub(crate) fn edges_slice(&self) -> &[Pos] {
+        if !self.edges.is_empty() && self.edges[0].node == gbwt::ENDMARKER {
+            return &self.edges[1..];
+        }
+        &self.edges
+    }
+
     /// Returns the sequence of the record.
     ///
     /// This is the sequence of the node in the correct orientation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,11 @@
 pub mod alignment;
 pub mod db;
 pub mod formats;
+pub mod path_index;
 pub mod subgraph;
 pub mod utils;
 
 pub use alignment::Alignment;
 pub use db::{GBZBase, GAFBase, GBZPath, GBZRecord, GraphInterface};
-pub use subgraph::{Subgraph, SubgraphQuery, HaplotypeOutput, PathIndex};
+pub use path_index::PathIndex;
+pub use subgraph::{Subgraph, SubgraphQuery, HaplotypeOutput};

--- a/src/path_index.rs
+++ b/src/path_index.rs
@@ -1,0 +1,189 @@
+//! And index for random access to GBZ paths by sequence offsets.
+//!
+//! This index extends the functionality of a [`GBZ`] graph to match [`crate::GraphInterface`].
+
+use gbwt::{GBZ, Pos, FullPathName};
+
+use simple_sds::sparse_vector::{SparseVector, SparseBuilder};
+use simple_sds::ops::PredSucc;
+
+use std::collections::HashMap;
+
+#[cfg(test)]
+mod tests;
+
+//-----------------------------------------------------------------------------
+
+// TODO: Should this be in the `gbwt` crate?
+/// An index for random access to reference and generic paths in a GBZ graph.
+///
+/// Indexed paths are identified by their offsets in the index.
+/// The offsets range from 0 to `path_count() - 1`.
+///
+/// The combination of [`GBZ`] and [`PathIndex`] is functionally similar to [`crate::GraphInterface`] but tens of times faster.
+/// An in-memory graph is better for batch operations, where the loading time is a negligible fraction of the total time.
+/// The database is better for interactive applications, where the user works with relatively small subgraphs.
+/// For a human graph, the database should be faster than the in-memory graph for subgraphs of up to 1 Mbp.
+///
+/// # Examples
+///
+/// ```
+/// use gbz_base::PathIndex;
+/// use gbwt::{GBZ, FullPathName, Pos, REF_SAMPLE};
+/// use gbwt::support;
+/// use simple_sds::serialize;
+///
+/// let filename = support::get_test_data("example.gbz");
+/// let graph: GBZ = serialize::load_from(&filename).unwrap();
+///
+/// // Create a path index with 3 bp intervals.
+/// let path_index = PathIndex::new(&graph, 3, false);
+/// assert!(path_index.is_ok());
+/// let path_index = path_index.unwrap();
+///
+/// // We have two components with one generic path in each.
+/// assert_eq!(path_index.path_count(), 2);
+/// assert_eq!(path_index.path_length(0), Some(5));
+/// assert_eq!(path_index.path_length(1), Some(4));
+///
+/// // Consider the generic path in component A.
+/// let path_name = FullPathName::generic("A");
+/// let index_offset = path_index.find_path(&graph, &path_name);
+/// assert_eq!(index_offset, Some(0));
+/// let index_offset = index_offset.unwrap();
+///
+/// // There should be two indexed positions for the path.
+/// let first_sample = path_index.indexed_position(index_offset, 2);
+/// assert_eq!(first_sample, Some((0, Pos::new(22, 0))));
+/// let second_sample = path_index.indexed_position(index_offset, 5);
+/// assert_eq!(second_sample, Some((3, Pos::new(30, 0))));
+/// let next_sample = path_index.indexed_position(index_offset, 100);
+/// assert_eq!(next_sample, second_sample);
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PathIndex {
+    // Maps path identifiers to index offsets.
+    path_to_offset: HashMap<usize, usize>,
+
+    // Maps index offsets to path identifiers.
+    offset_to_path: Vec<usize>,
+
+    // Sequence lengths for each path in bp.
+    path_lengths: Vec<usize>,
+
+    // Indexed sequence positions for each path.
+    sequence_positions: Vec<SparseVector>,
+
+    // GBWT positions corresponding to the indexed sequence positions.
+    gbwt_positions: Vec<Vec<Pos>>,
+}
+
+//-----------------------------------------------------------------------------
+
+impl PathIndex {
+    /// Creates a new path index for the given GBZ graph.
+    ///
+    /// The index is built for all reference and generic paths.
+    ///
+    /// # Arguments
+    ///
+    /// * `graph`: A GBZ graph.
+    /// * `interval`: Approximate distance between indexed positions (in bp).
+    /// * `verbose`: Print progress information to stderr.
+    pub fn new(graph: &GBZ, interval: usize, verbose: bool) -> Result<Self, String> {
+        if verbose {
+            eprintln!("Building path index");
+        }
+
+        // NOTE: For fragmented haplotypes, the reference positions are relative
+        // to the start of the fragment.
+        let reference_paths = graph.reference_positions(interval, verbose);
+        if reference_paths.is_empty() {
+            return Err(String::from("No reference paths to index"));
+        }
+
+        let mut path_to_offset: HashMap<usize, usize> = HashMap::with_capacity(reference_paths.len());
+        let mut offset_to_path: Vec<usize> = vec![0; reference_paths.len()];
+        let mut path_lengths: Vec<usize> = Vec::with_capacity(reference_paths.len());
+        let mut sequence_positions = Vec::with_capacity(reference_paths.len());
+        let mut gbwt_positions = Vec::with_capacity(reference_paths.len());
+        for (offset, ref_path) in reference_paths.iter().enumerate() {
+            path_to_offset.insert(ref_path.id, offset);
+            offset_to_path[offset] = ref_path.id;
+            path_lengths.push(ref_path.len);
+            let mut sequence = SparseBuilder::new(ref_path.len, ref_path.positions.len()).map_err(
+                String::from
+            )?;
+            let mut gbwt = Vec::with_capacity(ref_path.positions.len());
+            for (sequence_pos, gbwt_pos) in ref_path.positions.iter() {
+                sequence.set(*sequence_pos);
+                gbwt.push(*gbwt_pos);
+            }
+            sequence_positions.push(SparseVector::try_from(sequence).map_err(String::from)?);
+            gbwt_positions.push(gbwt);
+        }
+
+        Ok(PathIndex { path_to_offset, offset_to_path, path_lengths, sequence_positions, gbwt_positions })
+    }
+
+    /// Returns the number of indexed paths.
+    #[inline]
+    pub fn path_count(&self) -> usize {
+        self.sequence_positions.len()
+    }
+
+    /// Returns the index offset for the indexed path with the given identifier.
+    ///
+    /// Returns [`None`] if the path does not exist or it has not been indexed.
+    #[inline]
+    pub fn path_to_offset(&self, path_id: usize) -> Option<usize> {
+        self.path_to_offset.get(&path_id).cloned()
+    }
+
+    /// Returns the path identifier for the indexed path with the given index offset.
+    ///
+    /// Returns [`None`] if the path does not exist.
+    #[inline]
+    pub fn offset_to_path(&self, index_offset: usize) -> Option<usize> {
+        self.offset_to_path.get(index_offset).cloned()
+    }
+
+    /// Returns the index offset for the path with the given metadata.
+    ///
+    /// Returns [`None`] if the path does not exist or it has not been indexed.
+    pub fn find_path(&self, graph: &GBZ, path_name: &FullPathName) -> Option<usize> {
+        let metadata = graph.metadata()?;
+        let path_id = metadata.find_path(path_name)?;
+        self.path_to_offset(path_id)
+    }
+
+    /// Returns the length of the indexed path with the given index offset.
+    ///
+    /// Returns [`None`] if the path does not exist.
+    #[inline]
+    pub fn path_length(&self, index_offset: usize) -> Option<usize> {
+        self.path_lengths.get(index_offset).cloned()
+    }
+
+    /// Returns the last indexed position at or before `offset` on the path with name `path_name`.
+    ///
+    /// The return value consists of a sequence offset and a GBWT position.
+    /// Returns [`None`] if the path does not exist or it has not been indexed.
+    /// This is similar to [`crate::GraphInterface::find_path`] followed by [`crate::GraphInterface::indexed_position`].
+    ///
+    /// # Arguments
+    ///
+    /// * `index_offset`: Offset of the path in the index.
+    /// * `query_offset`: Sequence position in the path (in bp).
+    pub fn indexed_position(&self, index_offset: usize, query_offset: usize) -> Option<(usize, Pos)> {
+        let mut iter = self.sequence_positions[index_offset].predecessor(query_offset);
+        if let Some((sample_offset, sequence_offset)) = iter.next() {
+            let gbwt_pos = self.gbwt_positions[index_offset][sample_offset];
+            Some((sequence_offset, gbwt_pos))
+        } else {
+            None
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------

--- a/src/path_index/tests.rs
+++ b/src/path_index/tests.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+use gbwt::support;
+use simple_sds::serialize;
+
+//-----------------------------------------------------------------------------
+
+// TODO: We should also have a graph with reference paths for testing.
+// TODO: We should also have a graph with fragmented reference paths for testing.
+// TODO: We should also have a graph with longer nodes for testing.
+
+fn gbz_and_path_index(filename: &'static str, interval: usize) -> (GBZ, PathIndex) {
+    let gbz_file = support::get_test_data(filename);
+    let graph: GBZ = serialize::load_from(gbz_file).unwrap();
+    let path_index = PathIndex::new(&graph, interval, false);
+    if let Err(err) = path_index {
+        panic!("Failed to create path index with interval {}: {}", interval, err);
+    }
+    (graph, path_index.unwrap())
+}
+
+//-----------------------------------------------------------------------------
+
+#[test]
+fn path_index() {
+    for interval in 0..10 {
+        let (graph, path_index) = gbz_and_path_index("example.gbz", interval);
+        let metadata = graph.metadata().unwrap();
+
+        // Use the reference positions as the ground truth.
+        let reference_paths = graph.reference_positions(interval, false);
+        assert_eq!(path_index.path_count(), reference_paths.len(), "Path count mismatch for interval {}", interval);
+        for (index_offset, path) in reference_paths.iter().enumerate() {
+            assert_eq!(path_index.path_to_offset(path.id), Some(index_offset), "Wrong index offset for path {} with interval {}", path.id, interval);
+            assert_eq!(path_index.offset_to_path(index_offset), Some(path.id), "Wrong path for index offset {} with interval {}", index_offset, interval);
+            let path_name = FullPathName::from_metadata(&metadata, path.id).unwrap();
+            assert_eq!(path_index.find_path(&graph, &path_name), Some(index_offset), "Path not found for name {} with interval {}", path_name, interval);
+            assert_eq!(path_index.path_length(index_offset), Some(path.len), "Wrong path length for index offset {} with interval {}", index_offset, interval);
+
+            let mut pos_offset = 0;
+            for query_offset in 0..=path.len {
+                while pos_offset + 1 < path.positions.len() && path.positions[pos_offset + 1].0 <= query_offset {
+                    pos_offset += 1;
+                }
+                let truth = Some(path.positions[pos_offset]);
+                assert_eq!(path_index.indexed_position(index_offset, query_offset), truth, "Wrong indexed position for query offset {} with interval {}", query_offset, interval);
+            }
+        }
+
+        // Now try things that should not exist.
+        assert_eq!(path_index.path_to_offset(graph.paths()), None, "Found an index offset for a nonexistent path with interval {}", interval);
+        assert_eq!(path_index.offset_to_path(reference_paths.len()), None, "Found a path for a nonexistent index offset with interval {}", interval);
+        let path_name = FullPathName::generic("nonexistent");
+        assert_eq!(path_index.find_path(&graph, &path_name), None, "Found a nonexistent path by name with interval {}", interval);
+        assert_eq!(path_index.path_length(reference_paths.len()), None, "Found a length for a nonexistent index offset with interval {}", interval);
+    }
+}
+
+//-----------------------------------------------------------------------------

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -4,6 +4,8 @@
 //! The subgraph contains all nodes within a given context and all edges between them.
 //! All other paths within the subgraph can also be extracted, but they will not have any true metadata associated with them.
 
+// TODO: Could we just provide the GBZ / DB versions of get_record() somewhere?
+
 use crate::{GBZRecord, GBZPath, GraphInterface, PathIndex};
 use crate::formats::{self, WalkMetadata, JSONValue};
 
@@ -182,7 +184,7 @@ impl Display for SubgraphQuery {
 /// * [`Subgraph::around_interval`] for a context around path interval.
 /// * [`Subgraph::around_nodes`] for a context around a set of nodes.
 ///
-/// [`Subgraph::from_gbz`] and [`Subgraph::from_db`] are integrated methods for extracting a subgraph using a [`SubgraphQuery`].
+/// [`Subgraph::from_gbz`] and [`Subgraph::from_db`] are integrated methods for extracting a subgraph with paths using a [`SubgraphQuery`].
 ///
 /// `Subgraph` implements a similar graph interface to the node/edge operations of [`GBZ`].
 /// It can also be serialized in GFA and JSON formats using [`Subgraph::write_gfa`] and [`Subgraph::write_json`].

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -4,11 +4,11 @@
 //! The subgraph contains all nodes within a given context and all edges between them.
 //! All other paths within the subgraph can also be extracted, but they will not have any true metadata associated with them.
 
-use crate::{GBZRecord, GBZPath, GraphInterface};
+use crate::{GBZRecord, GBZPath, GraphInterface, PathIndex};
 use crate::formats::{self, WalkMetadata, JSONValue};
 
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, BTreeMap, BTreeSet, HashMap};
+use std::collections::{BinaryHeap, BTreeMap, BTreeSet};
 use std::fmt::Display;
 use std::io::{self, Write};
 use std::ops::Range;
@@ -18,9 +18,6 @@ use gbwt::ENDMARKER;
 use gbwt::{GBZ, GBWT, GraphPosition, Orientation, Pos, FullPathName};
 
 use gbwt::{algorithms, support};
-
-use simple_sds::sparse_vector::{SparseVector, SparseBuilder};
-use simple_sds::ops::PredSucc;
 
 #[cfg(test)]
 mod tests;
@@ -203,181 +200,22 @@ impl Display for SubgraphQuery {
 
 //-----------------------------------------------------------------------------
 
-/// An index for random access to reference and generic paths in a GBZ graph.
-///
-/// Indexed paths are identified by their offsets in the index.
-/// The offsets range from 0 to `path_count() - 1`.
-///
-/// The combination of [`GBZ`] and [`PathIndex`] is functionally similar to [`GraphInterface`] but tens of times faster.
-/// An in-memory graph is better for batch operations, where the loading time is a negligible fraction of the total time.
-/// The database is better for interactive applications, where the user works with relatively small subgraphs.
-/// For a human graph, the database should be faster than the in-memory graph for subgraphs of up to 1 Mbp.
-///
-/// # Examples
-///
-/// ```
-/// use gbz_base::PathIndex;
-/// use gbwt::{GBZ, FullPathName, Pos, REF_SAMPLE};
-/// use gbwt::support;
-/// use simple_sds::serialize;
-///
-/// let filename = support::get_test_data("example.gbz");
-/// let graph: GBZ = serialize::load_from(&filename).unwrap();
-///
-/// // Create a path index with 3 bp intervals.
-/// let path_index = PathIndex::new(&graph, 3, false);
-/// assert!(path_index.is_ok());
-/// let path_index = path_index.unwrap();
-///
-/// // We have two components with one generic path in each.
-/// assert_eq!(path_index.path_count(), 2);
-/// assert_eq!(path_index.path_length(0), Some(5));
-/// assert_eq!(path_index.path_length(1), Some(4));
-///
-/// // Consider the generic path in component A.
-/// let path_name = FullPathName::generic("A");
-/// let index_offset = path_index.find_path(&graph, &path_name);
-/// assert_eq!(index_offset, Some(0));
-/// let index_offset = index_offset.unwrap();
-///
-/// // There should be two indexed positions for the path.
-/// let first_sample = path_index.indexed_position(index_offset, 2);
-/// assert_eq!(first_sample, Some((0, Pos::new(22, 0))));
-/// let second_sample = path_index.indexed_position(index_offset, 5);
-/// assert_eq!(second_sample, Some((3, Pos::new(30, 0))));
-/// let next_sample = path_index.indexed_position(index_offset, 100);
-/// assert_eq!(next_sample, second_sample);
-/// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PathIndex {
-    // Maps path identifiers to index offsets.
-    path_to_offset: HashMap<usize, usize>,
+// FIXME: Tests for the new functionality.
 
-    // Maps index offsets to path identifiers.
-    offset_to_path: HashMap<usize, usize>,
-
-    // Sequence lengths for each path in bp.
-    path_lengths: Vec<usize>,
-
-    // Indexed sequence positions for each path.
-    sequence_positions: Vec<SparseVector>,
-
-    // GBWT positions corresponding to the indexed sequence positions.
-    gbwt_positions: Vec<Vec<Pos>>,
-}
-
-impl PathIndex {
-    /// Creates a new path index for the given GBZ graph.
-    ///
-    /// The index is built for all reference and generic paths.
-    ///
-    /// # Arguments
-    ///
-    /// * `graph`: A GBZ graph.
-    /// * `interval`: Approximate distance between indexed positions (in bp).
-    /// * `verbose`: Print progress information to stderr.
-    pub fn new(graph: &GBZ, interval: usize, verbose: bool) -> Result<Self, String> {
-        if verbose {
-            eprintln!("Building path index");
-        }
-
-        // NOTE: For fragmented haplotypes, the reference positions are relative
-        // to the start of the fragment.
-        let reference_paths = graph.reference_positions(interval, verbose);
-        if reference_paths.is_empty() {
-            return Err(String::from("No reference paths to index"));
-        }
-
-        let mut path_to_offset: HashMap<usize, usize> = HashMap::with_capacity(reference_paths.len());
-        let mut offset_to_path: HashMap<usize, usize> = HashMap::with_capacity(reference_paths.len());
-        let mut path_lengths: Vec<usize> = Vec::with_capacity(reference_paths.len());
-        let mut sequence_positions = Vec::with_capacity(reference_paths.len());
-        let mut gbwt_positions = Vec::with_capacity(reference_paths.len());
-        for ref_path in reference_paths.iter() {
-            path_to_offset.insert(ref_path.id, path_to_offset.len());
-            offset_to_path.insert(offset_to_path.len(), ref_path.id);
-            path_lengths.push(ref_path.len);
-            let mut sequence = SparseBuilder::new(ref_path.len, ref_path.positions.len()).map_err(
-                String::from
-            )?;
-            let mut gbwt = Vec::with_capacity(ref_path.positions.len());
-            for (sequence_pos, gbwt_pos) in ref_path.positions.iter() {
-                sequence.set(*sequence_pos);
-                gbwt.push(*gbwt_pos);
-            }
-            sequence_positions.push(SparseVector::try_from(sequence).map_err(String::from)?);
-            gbwt_positions.push(gbwt);
-        }
-
-        Ok(PathIndex { path_to_offset, offset_to_path, path_lengths, sequence_positions, gbwt_positions })
-    }
-
-    /// Returns the number of indexed paths.
-    pub fn path_count(&self) -> usize {
-        self.sequence_positions.len()
-    }
-
-    /// Returns the index offset for the indexed path with the given identifier.
-    ///
-    /// Returns [`None`] if the path does not exist or it has not been indexed.
-    pub fn path_to_offset(&self, path_id: usize) -> Option<usize> {
-        self.path_to_offset.get(&path_id).cloned()
-    }
-
-    /// Returns the path identifier for the indexed path with the given index offset.
-    ///
-    /// Returns [`None`] if the path does not exist.
-    pub fn offset_to_path(&self, index_offset: usize) -> Option<usize> {
-        self.offset_to_path.get(&index_offset).cloned()
-    }
-
-    /// Returns the index offset for the path with the given metadata.
-    ///
-    /// Returns [`None`] if the path does not exist or it has not been indexed.
-    pub fn find_path(&self, graph: &GBZ, path_name: &FullPathName) -> Option<usize> {
-        let metadata = graph.metadata()?;
-        let path_id = metadata.find_path(path_name)?;
-        self.path_to_offset(path_id)
-    }
-
-    /// Returns the length of the indexed path with the given index offset.
-    ///
-    /// Returns [`None`] if the path does not exist.
-    pub fn path_length(&self, index_offset: usize) -> Option<usize> {
-        self.path_lengths.get(index_offset).cloned()
-    }
-
-    /// Returns the last indexed position at or before `offset` on the path with name `path_name`.
-    ///
-    /// The return value consists of a sequence offset and a GBWT position.
-    /// Returns [`None`] if the path does not exist or it has not been indexed.
-    /// This is similar to [`GraphInterface::find_path`] followed by [`GraphInterface::indexed_position`].
-    ///
-    /// # Arguments
-    ///
-    /// * `index_offset`: Offset of the path in the index.
-    /// * `query_offset`: Sequence position in the path (in bp).
-    pub fn indexed_position(&self, index_offset: usize, query_offset: usize) -> Option<(usize, Pos)> {
-        let mut iter = self.sequence_positions[index_offset].predecessor(query_offset);
-        if let Some((sample_offset, sequence_offset)) = iter.next() {
-            let gbwt_pos = self.gbwt_positions[index_offset][sample_offset];
-            Some((sequence_offset, gbwt_pos))
-        } else {
-            None
-        }
-    }
-}
-
-//-----------------------------------------------------------------------------
-
-// FIXME: Tests and examples for the new functionality.
-
-// FIXME: Document the intended use of this struct, for example as a sliding window over a reference path.
+// FIXME: example that replicates from_gbz with a path offset using lower-level functions.
 /// A subgraph based on a context around a graph position.
 ///
 /// The position can be based on a path offset, a path interval, or a node identifier.
 /// The path used for extracting the subgraph becomes the reference path for it.
 /// Non-reference haplotypes do not have any metadata associated with them, as we cannot determine the identifier of a path from its GBWT position efficiently.
+///
+/// This struct is intended to be used as a sliding window in the graph.
+/// Individual nodes can be added and removed with the [`Subgraph::add_node`] and [`Subgraph::remove_node`] methods.
+/// The subgraph can be updated to a new context with the [`Subgraph::around_position`] and [`Subgraph::around_node`] methods.
+/// These methods reuse existing records when possible.
+/// Changes to the subgraph do not preserve paths; they must be re-extracted with the [`Subgraph::extract_paths`] method.
+/// [`Subgraph::from_gbz`] and [`Subgraph::from_db`] are convenience methods for extracting a subgraph using a [`SubgraphQuery`].
+/// The subgraph can be converted to GFA or JSON with the [`Subgraph::write_gfa`] and [`Subgraph::write_json`] methods.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Subgraph {
     // Node records for the subgraph.
@@ -662,20 +500,12 @@ impl Subgraph {
             let path_index = path_index.ok_or(
                 String::from("Path index is required for path-based queries")
             )?;
-            let path_name = query.path_name_with_offset();
-            let ref_path = GBZPath::with_name(graph, &path_name).ok_or(
-                format!("Cannot find a path covering {}", path_name)
-            )?;
-            // Transform the offset relative to the haplotype to the offset relative to the path.
-            let query_offset = path_name.fragment - ref_path.name.fragment;
-
-            // Now we can build the subgraph.
-            let ref_pos = query_position_from_gbz(graph, path_index, &ref_path, query_offset)?;
-            let reference_path = Some((ref_pos, ref_path.name));
-            self.around_position(ref_pos.graph_pos, query.context, &mut |handle| {
+            let query_pos = query.path_name_with_offset();
+            let reference_path = reference_position_from_gbz(graph, path_index, query_pos)?;
+            self.around_position(reference_path.0.graph_pos, query.context, &mut |handle| {
                 GBZRecord::from_gbz(graph, handle).ok_or(format!("The graph does not contain handle {}", handle))
             })?;
-            self.extract_paths(reference_path, query.output())?;
+            self.extract_paths(Some(reference_path), query.output())?;
         } else if query.is_node_based() {
             if query.output() == HaplotypeOutput::ReferenceOnly {
                 return Err(String::from("Cannot output a reference path in a node-based query"));
@@ -741,23 +571,13 @@ impl Subgraph {
     pub fn from_db(&mut self, graph: &mut GraphInterface, query: &SubgraphQuery) -> Result<(), String> {
         // FIXME: Do interval-based properly.
         if query.is_path_based() {
-            let path_name = query.path_name_with_offset();
-            let ref_path = graph.find_path(&path_name)?;
-            let ref_path = ref_path.ok_or(format!("Cannot find a path covering {}", path_name))?;
-            if !ref_path.is_indexed {
-                return Err(format!("Path {} has not been indexed for random access", ref_path.name));
-            }
-            // Transform the offset relative to the haplotype to the offset relative to the path.
-            let query_offset = path_name.fragment - ref_path.name.fragment;
-
-            // Now we can build the subgraph.
-            let ref_pos = query_position_from_db(graph, &ref_path, query_offset)?;
-            let reference_path = Some((ref_pos, ref_path.name));
-            self.around_position(ref_pos.graph_pos, query.context, &mut |handle| {
+            let query_pos = query.path_name_with_offset();
+            let reference_path = reference_position_from_db(graph, query_pos)?;
+            self.around_position(reference_path.0.graph_pos, query.context, &mut |handle| {
                 let record = graph.get_record(handle)?;
                 record.ok_or(format!("The graph does not contain handle {}", handle))
             })?;
-            self.extract_paths(reference_path, query.output())?;
+            self.extract_paths(Some(reference_path), query.output())?;
         } else if query.is_node_based() {
             if query.output() == HaplotypeOutput::ReferenceOnly {
                 return Err(String::from("Cannot output a reference path in a node-based query"));
@@ -789,6 +609,7 @@ impl Subgraph {
         }
     }
 
+    // FIXME: Example using add_node and remove_node.
     /// Extracts all paths in the subgraph.
     ///
     /// Clears the current paths in the subgraph.
@@ -1032,8 +853,8 @@ impl Subgraph {
         self.paths.len()
     }
 
-    /// Clears all path information from the subgraph.
-    pub fn clear_paths(&mut self) {
+    // Clears all path information from the subgraph.
+    fn clear_paths(&mut self) {
         self.paths.clear();
         self.ref_id = None;
         self.ref_path = None;
@@ -1377,8 +1198,27 @@ impl Subgraph {
 
 //-----------------------------------------------------------------------------
 
-// Returns the graph position and the GBWT position for the given offset.
-fn query_position_from_db(graph: &mut GraphInterface, path: &GBZPath, query_offset: usize) -> Result<PathPosition, String> {
+// FIXME: This should be a method that updates the subgraph.
+// FIXME: example
+/// Returns the path position for the haplotype offset represented by the query position.
+///
+/// `query_pos.fragment` is used as an offset in the haplotype.
+/// The return value consists of the position and metadata for the path covering the position.
+///
+/// # Errors
+///
+/// Returns an error if database operations fail.
+/// Returns an error if there is no path covering the given position or the path has not been indexed for random access.
+pub fn reference_position_from_db(graph: &mut GraphInterface, query_pos: FullPathName) -> Result<(PathPosition, FullPathName), String> {
+    let path = graph.find_path(&query_pos)?;
+    let path = path.ok_or(format!("Cannot find a path covering {}", query_pos))?;
+    if !path.is_indexed {
+        return Err(format!("Path {} has not been indexed for random access", query_pos));
+    }
+    // Transform the offset relative to the haplotype to the offset relative to the path.
+    let query_offset = query_pos.fragment - path.name.fragment;
+
+    // Find an indexed position before the query position.
     let result = graph.indexed_position(path.handle, query_offset)?;
     let (mut path_offset, mut pos) = result.ok_or(
         format!("Path {} has not been indexed for random access", path.name())
@@ -1412,15 +1252,32 @@ fn query_position_from_db(graph: &mut GraphInterface, path: &GBZPath, query_offs
         format!("Path {} does not contain offset {}", path.name(), query_offset)
     )?;
     let gbwt_pos = gbwt_pos.unwrap();
-    Ok(PathPosition {
+
+    let path_position = PathPosition {
         seq_offset: query_offset,
         graph_pos,
         gbwt_pos,
-    })
+    };
+    Ok((path_position, path.name))
 }
 
-// Returns the graph position and the GBWT position for the given offset.
-fn query_position_from_gbz(graph: &GBZ, path_index: &PathIndex, path: &GBZPath, query_offset: usize) -> Result<PathPosition, String> {
+// FIXME: This should be a method that updates the subgraph.
+// FIXME: example
+/// Returns the path position for the haplotype offset represented by the query position.
+///
+/// `query_pos.fragment` is used as an offset in the haplotype.
+/// The return value consists of the position and metadata for the path covering the position.
+///
+/// # Errors
+///
+/// Returns an error if there is no path covering the given position or the path has not been indexed for random access.
+pub fn reference_position_from_gbz(graph: &GBZ, path_index: &PathIndex, query_pos: FullPathName) -> Result<(PathPosition, FullPathName), String> {
+    let path = GBZPath::with_name(graph, &query_pos).ok_or(
+        format!("Cannot find a path covering {}", query_pos)
+    )?;
+    // Transform the offset relative to the haplotype to the offset relative to the path.
+    let query_offset = query_pos.fragment - path.name.fragment;
+
     // Path id to an indexed position.
     let index_offset = path_index.path_to_offset(path.handle).ok_or(
         format!("Path {} has not been indexed for random access", path.name())
@@ -1454,11 +1311,13 @@ fn query_position_from_gbz(graph: &GBZ, path_index: &PathIndex, path: &GBZPath, 
         format!("Path {} does not contain offset {}", path.name(), query_offset)
     )?;
     let gbwt_pos = gbwt_pos.unwrap();
-    Ok(PathPosition {
+
+    let path_position = PathPosition {
         seq_offset: query_offset,
         graph_pos,
         gbwt_pos,
-    })
+    };
+    Ok((path_position, path.name))
 }
 
 //-----------------------------------------------------------------------------
@@ -1466,7 +1325,7 @@ fn query_position_from_gbz(graph: &GBZ, path_index: &PathIndex, path: &GBZPath, 
 /// A path position represented in multiple ways.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PathPosition {
-    /// Offset in the path in bp.
+    /// Sequence offset in in bp.
     pub seq_offset: usize,
     /// Graph position corresponding to the offset.
     pub graph_pos: GraphPosition,

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -543,8 +543,8 @@ fn subgraph_from_gbz() {
         if let Err(err) = result {
             panic!("Failed to create subgraph for query {}: {}", query, err);
         }
-        assert_eq!(subgraph.node_count(), *node_count, "Wrong node count for query {}", query);
-        assert_eq!(subgraph.path_count(), *path_count, "Wrong path count for query {}", query);
+        assert_eq!(subgraph.nodes(), *node_count, "Wrong node count for query {}", query);
+        assert_eq!(subgraph.paths(), *path_count, "Wrong path count for query {}", query);
     }
 }
 
@@ -564,8 +564,8 @@ fn subgraph_from_db() {
         if let Err(err) = result {
             panic!("Failed to create subgraph for query {}: {}", query, err);
         }
-        assert_eq!(subgraph.node_count(), *node_count, "Wrong node count for query {}", query);
-        assert_eq!(subgraph.path_count(), *path_count, "Wrong path count for query {}", query);
+        assert_eq!(subgraph.nodes(), *node_count, "Wrong node count for query {}", query);
+        assert_eq!(subgraph.paths(), *path_count, "Wrong path count for query {}", query);
     }
 
     drop(graph);

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -361,7 +361,7 @@ fn queries_and_counts() -> (Vec<SubgraphQuery>, Vec<(usize, usize)>) {
     let queries = vec![
         SubgraphQuery::path_offset(&path_a, 2, 1, HaplotypeOutput::All),
         SubgraphQuery::path_offset(&path_a, 2, 1, HaplotypeOutput::Distinct),
-        SubgraphQuery::node(14, 1, HaplotypeOutput::Distinct),
+        SubgraphQuery::nodes([14], 1, HaplotypeOutput::Distinct),
         SubgraphQuery::path_offset(&path_a, 2, 1, HaplotypeOutput::ReferenceOnly),
         SubgraphQuery::path_offset(&path_b, 2, 1, HaplotypeOutput::Distinct),
     ];
@@ -381,7 +381,7 @@ fn queries_and_gfas(cigar: bool) -> (Vec<SubgraphQuery>, Vec<Vec<String>>){
     let queries = vec![
         SubgraphQuery::path_offset(&path_a, 2, 1, HaplotypeOutput::All),
         SubgraphQuery::path_offset(&path_a, 2, 1, HaplotypeOutput::Distinct),
-        SubgraphQuery::node(14, 1, HaplotypeOutput::Distinct),
+        SubgraphQuery::nodes([14], 1, HaplotypeOutput::Distinct),
         SubgraphQuery::path_offset(&path_a, 2, 1, HaplotypeOutput::ReferenceOnly),
         SubgraphQuery::path_offset(&path_b, 2, 1, HaplotypeOutput::Distinct),
     ];
@@ -465,7 +465,7 @@ fn queries_and_jsons(cigar: bool) -> (Vec<SubgraphQuery>, Vec<String>){
     let queries = vec![
         SubgraphQuery::path_offset(&path_a, 2, 1, HaplotypeOutput::All),
         SubgraphQuery::path_offset(&path_a, 2, 1, HaplotypeOutput::Distinct),
-        SubgraphQuery::node(14, 1, HaplotypeOutput::Distinct),
+        SubgraphQuery::nodes([14], 1, HaplotypeOutput::Distinct),
         SubgraphQuery::path_offset(&path_a, 2, 1, HaplotypeOutput::ReferenceOnly),
     ];
 

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -575,11 +575,11 @@ fn subgraph_from_gbz() {
     let (graph, path_index) = gbz_and_path_index("example.gbz", GBZBase::INDEX_INTERVAL);
     let (queries, nodes_and_paths) = queries_and_counts();
     for (query, (node_count, path_count)) in queries.iter().zip(nodes_and_paths.iter()) {
-        let subgraph = Subgraph::from_gbz(&graph, Some(&path_index), query);
-        if let Err(err) = subgraph {
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_gbz(&graph, Some(&path_index), query);
+        if let Err(err) = result {
             panic!("Failed to create subgraph for query {}: {}", query, err);
         }
-        let subgraph = subgraph.unwrap();
         assert_eq!(subgraph.node_count(), *node_count, "Wrong node count for query {}", query);
         assert_eq!(subgraph.path_count(), *path_count, "Wrong path count for query {}", query);
     }
@@ -596,11 +596,11 @@ fn subgraph_from_db() {
 
     let (queries, nodes_and_paths) = queries_and_counts();
     for (query, (node_count, path_count)) in queries.iter().zip(nodes_and_paths.iter()) {
-        let subgraph = Subgraph::from_db(&mut graph, query);
-        if let Err(err) = subgraph {
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_db(&mut graph, query);
+        if let Err(err) = result {
             panic!("Failed to create subgraph for query {}: {}", query, err);
         }
-        let subgraph = subgraph.unwrap();
         assert_eq!(subgraph.node_count(), *node_count, "Wrong node count for query {}", query);
         assert_eq!(subgraph.path_count(), *path_count, "Wrong path count for query {}", query);
     }
@@ -618,7 +618,8 @@ fn gfa_output() {
     for cigar in [false, true] {
         let (queries, gfas) = queries_and_gfas(cigar);
         for (query, truth) in queries.iter().zip(gfas.iter()) {
-            let subgraph = Subgraph::from_gbz(&graph, Some(&path_index), query).unwrap();
+            let mut subgraph = Subgraph::new();
+            let _ = subgraph.from_gbz(&graph, Some(&path_index), query);
             let mut output = Vec::new();
             let result = subgraph.write_gfa(&mut output, cigar);
             assert!(result.is_ok(), "Failed to write GFA for query {}: {}", query, result.unwrap_err());
@@ -638,7 +639,8 @@ fn json_output() {
     for cigar in [false, true] {
         let (queries, jsons) = queries_and_jsons(cigar);
         for (query, truth) in queries.iter().zip(jsons.iter()) {
-            let subgraph = Subgraph::from_gbz(&graph, Some(&path_index), query).unwrap();
+            let mut subgraph = Subgraph::new();
+            let _ = subgraph.from_gbz(&graph, Some(&path_index), query);
             let mut output = Vec::new();
             let result = subgraph.write_json(&mut output, cigar);
             assert!(result.is_ok(), "Failed to write JSON for query {}: {}", query, result.unwrap_err());

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -534,43 +534,6 @@ fn queries_and_jsons(cigar: bool) -> (Vec<SubgraphQuery>, Vec<String>){
 //-----------------------------------------------------------------------------
 
 #[test]
-fn path_index() {
-    for interval in 0..10 {
-        let (graph, path_index) = gbz_and_path_index("example.gbz", interval);
-        let metadata = graph.metadata().unwrap();
-
-        // Use the reference positions as the ground truth.
-        let reference_paths = graph.reference_positions(interval, false);
-        assert_eq!(path_index.path_count(), reference_paths.len(), "Path count mismatch for interval {}", interval);
-        for (index_offset, path) in reference_paths.iter().enumerate() {
-            assert_eq!(path_index.path_to_offset(path.id), Some(index_offset), "Wrong index offset for path {} with interval {}", path.id, interval);
-            assert_eq!(path_index.offset_to_path(index_offset), Some(path.id), "Wrong path for index offset {} with interval {}", index_offset, interval);
-            let path_name = FullPathName::from_metadata(&metadata, path.id).unwrap();
-            assert_eq!(path_index.find_path(&graph, &path_name), Some(index_offset), "Path not found for name {} with interval {}", path_name, interval);
-            assert_eq!(path_index.path_length(index_offset), Some(path.len), "Wrong path length for index offset {} with interval {}", index_offset, interval);
-
-            let mut pos_offset = 0;
-            for query_offset in 0..=path.len {
-                while pos_offset + 1 < path.positions.len() && path.positions[pos_offset + 1].0 <= query_offset {
-                    pos_offset += 1;
-                }
-                let truth = Some(path.positions[pos_offset]);
-                assert_eq!(path_index.indexed_position(index_offset, query_offset), truth, "Wrong indexed position for query offset {} with interval {}", query_offset, interval);
-            }
-        }
-
-        // Now try things that should not exist.
-        assert_eq!(path_index.path_to_offset(graph.paths()), None, "Found an index offset for a nonexistent path with interval {}", interval);
-        assert_eq!(path_index.offset_to_path(reference_paths.len()), None, "Found a path for a nonexistent index offset with interval {}", interval);
-        let path_name = FullPathName::generic("nonexistent");
-        assert_eq!(path_index.find_path(&graph, &path_name), None, "Found a nonexistent path by name with interval {}", interval);
-        assert_eq!(path_index.path_length(reference_paths.len()), None, "Found a length for a nonexistent index offset with interval {}", interval);
-    }
-}
-
-//-----------------------------------------------------------------------------
-
-#[test]
 fn subgraph_from_gbz() {
     let (graph, path_index) = gbz_and_path_index("example.gbz", GBZBase::INDEX_INTERVAL);
     let (queries, nodes_and_paths) = queries_and_counts();

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -357,34 +357,34 @@ fn gbz_and_path_index(filename: &'static str, interval: usize) -> (GBZ, PathInde
     (graph, path_index.unwrap())
 }
 
-fn check_subgraph(graph: &GBZ, subgraph: &Subgraph, true_nodes: &[usize], path_count: usize) {
+fn check_subgraph(graph: &GBZ, subgraph: &Subgraph, true_nodes: &[usize], path_count: usize, test_case: &str) {
     // Counts.
-    assert_eq!(subgraph.nodes(), true_nodes.len(), "Wrong number of nodes in subgraph");
-    assert_eq!(subgraph.paths(), path_count, "Wrong number of paths in subgraph");
+    assert_eq!(subgraph.nodes(), true_nodes.len(), "Wrong number of nodes for {}", test_case);
+    assert_eq!(subgraph.paths(), path_count, "Wrong number of paths for {}", test_case);
 
     // Minimum and maximum node ids, assuming that `true_nodes` is sorted.
     if !true_nodes.is_empty() {
-        assert_eq!(subgraph.min_node(), true_nodes.first().copied(), "Wrong minimum node id in subgraph");
-        assert_eq!(subgraph.max_node(), true_nodes.last().copied(), "Wrong maximum node id in subgraph");
+        assert_eq!(subgraph.min_node(), true_nodes.first().copied(), "Wrong minimum node id for {}", test_case);
+        assert_eq!(subgraph.max_node(), true_nodes.last().copied(), "Wrong maximum node id for {}", test_case);
     }
 
     // Node ids and sequences.
-    assert!(subgraph.node_iter().eq(true_nodes.iter().copied()), "Wrong node ids in subgraph");
+    assert!(subgraph.node_iter().eq(true_nodes.iter().copied()), "Wrong node ids for {}", test_case);
     for node_id in graph.node_iter() {
         if true_nodes.contains(&node_id) {
-            assert!(subgraph.has_node(node_id), "Subgraph does not contain node {}", node_id);
+            assert!(subgraph.has_node(node_id), "Subgraph {} does not contain node {}", test_case, node_id);
             let forward = graph.sequence(node_id).unwrap();
             let reverse = support::reverse_complement(forward);
-            assert_eq!(subgraph.sequence(node_id), Some(forward), "Subgraph has wrong sequence for node {}", node_id);
-            assert_eq!(subgraph.oriented_sequence(node_id, Orientation::Forward), Some(forward), "Subgraph has wrong forward sequence for node {}", node_id);
-            assert_eq!(subgraph.oriented_sequence(node_id, Orientation::Reverse), Some(reverse.as_slice()), "Subgraph has wrong reverse sequence for node {}", node_id);
-            assert_eq!(subgraph.sequence_len(node_id), Some(forward.len()), "Subgraph has wrong sequence length for node {}", node_id);
+            assert_eq!(subgraph.sequence(node_id), Some(forward), "Subgraph {} has wrong sequence for node {}", test_case, node_id);
+            assert_eq!(subgraph.oriented_sequence(node_id, Orientation::Forward), Some(forward), "Subgraph {} has wrong forward sequence for node {}", test_case, node_id);
+            assert_eq!(subgraph.oriented_sequence(node_id, Orientation::Reverse), Some(reverse.as_slice()), "Subgraph {} has wrong reverse sequence for node {}", test_case, node_id);
+            assert_eq!(subgraph.sequence_len(node_id), Some(forward.len()), "Subgraph {} has wrong sequence length for node {}", test_case, node_id);
         } else {
-            assert!(!subgraph.has_node(node_id), "Subgraph contains node {}", node_id);
-            assert!(subgraph.sequence(node_id).is_none(), "Subgraph contains sequence for node {}", node_id);
-            assert!(subgraph.oriented_sequence(node_id, Orientation::Forward).is_none(), "Subgraph contains forward sequence for node {}", node_id);
-            assert!(subgraph.oriented_sequence(node_id, Orientation::Reverse).is_none(), "Subgraph contains reverse sequence for node {}", node_id);
-            assert!(subgraph.sequence_len(node_id).is_none(), "Subgraph contains sequence length for node {}", node_id);
+            assert!(!subgraph.has_node(node_id), "Subgraph {} contains node {}", test_case, node_id);
+            assert!(subgraph.sequence(node_id).is_none(), "Subgraph {} contains sequence for node {}", test_case, node_id);
+            assert!(subgraph.oriented_sequence(node_id, Orientation::Forward).is_none(), "Subgraph {} contains forward sequence for node {}", test_case, node_id);
+            assert!(subgraph.oriented_sequence(node_id, Orientation::Reverse).is_none(), "Subgraph {} contains reverse sequence for node {}", test_case, node_id);
+            assert!(subgraph.sequence_len(node_id).is_none(), "Subgraph {} contains sequence length for node {}", test_case, node_id);
         }
     }
 
@@ -394,18 +394,18 @@ fn check_subgraph(graph: &GBZ, subgraph: &Subgraph, true_nodes: &[usize], path_c
             if subgraph.has_node(node_id) {
                 let graph_succ = graph.successors(node_id, orientation).unwrap();
                 let subgraph_succ = subgraph.successors(node_id, orientation);
-                assert!(subgraph_succ.is_some(), "Subgraph does not contain successors for node {} ({})", node_id, orientation);
+                assert!(subgraph_succ.is_some(), "Subgraph {} does not contain successors for node {} ({})", test_case, node_id, orientation);
                 let subgraph_succ = subgraph_succ.unwrap();
-                assert!(graph_succ.filter(|(id, _)| subgraph.has_node(*id)).eq(subgraph_succ), "Subgraph has wrong successors for node {} ({})", node_id, orientation);
+                assert!(graph_succ.filter(|(id, _)| subgraph.has_node(*id)).eq(subgraph_succ), "Subgraph {} has wrong successors for node {} ({})", test_case, node_id, orientation);
 
                 let graph_pred = graph.predecessors(node_id, orientation).unwrap();
                 let subgraph_pred = subgraph.predecessors(node_id, orientation);
-                assert!(subgraph_pred.is_some(), "Subgraph does not contain predecessors for node {} ({})", node_id, orientation);
+                assert!(subgraph_pred.is_some(), "Subgraph {} does not contain predecessors for node {} ({})", test_case, node_id, orientation);
                 let subgraph_pred = subgraph_pred.unwrap();
-                assert!(graph_pred.filter(|(id, _)| subgraph.has_node(*id)).eq(subgraph_pred), "Subgraph has wrong predecessors for node {} ({})", node_id, orientation);
+                assert!(graph_pred.filter(|(id, _)| subgraph.has_node(*id)).eq(subgraph_pred), "Subgraph {} has wrong predecessors for node {} ({})", test_case, node_id, orientation);
             } else {
-                assert!(subgraph.successors(node_id, orientation).is_none(), "Subgraph contains successors for node {} ({})", node_id, orientation);
-                assert!(subgraph.predecessors(node_id, orientation).is_none(), "Subgraph contains predecessors for node {} ({})", node_id, orientation);
+                assert!(subgraph.successors(node_id, orientation).is_none(), "Subgraph {} contains successors for node {} ({})", test_case, node_id, orientation);
+                assert!(subgraph.predecessors(node_id, orientation).is_none(), "Subgraph {} contains predecessors for node {} ({})", test_case, node_id, orientation);
             }
         }
     }
@@ -595,10 +595,6 @@ fn queries_and_jsons(cigar: bool) -> (Vec<SubgraphQuery>, Vec<String>){
 
 // Construction and operations.
 
-// FIXME: path_pos_from_gbz() and path_pos_from_db()
-
-// FIXME: around_position(), around_interval(), and around_nodes(); + extract_paths()
-
 #[test]
 fn random_nodes() {
     let gbz_file = support::get_test_data("example.gbz");
@@ -630,7 +626,7 @@ fn random_nodes() {
 
     // We have a subgraph with known nodes and no paths.
     let true_nodes: Vec<usize> = selected.iter().copied().collect();
-    check_subgraph(&graph, &subgraph, &true_nodes, 0);
+    check_subgraph(&graph, &subgraph, &true_nodes, 0, "(random nodes)");
 }
 
 #[test]
@@ -643,7 +639,7 @@ fn subgraph_from_gbz() {
         if let Err(err) = result {
             panic!("Failed to create subgraph for query {}: {}", query, err);
         }
-        check_subgraph(&graph, &subgraph, &true_nodes, *path_count);
+        check_subgraph(&graph, &subgraph, &true_nodes, *path_count, &query.to_string());
     }
 }
 
@@ -664,7 +660,133 @@ fn subgraph_from_db() {
         if let Err(err) = result {
             panic!("Failed to create subgraph for query {}: {}", query, err);
         }
-        check_subgraph(&gbz_graph, &subgraph, &true_nodes, *path_count);
+        check_subgraph(&gbz_graph, &subgraph, &true_nodes, *path_count, &query.to_string());
+    }
+
+    drop(graph);
+    drop(database);
+    fs::remove_file(&db_file).unwrap();
+}
+
+#[test]
+fn manual_gbz_queries() {
+    let (graph, path_index) = gbz_and_path_index("example.gbz", GBZBase::INDEX_INTERVAL);
+    let (queries, truth) = queries_and_truth();
+    for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
+        let mut subgraph = Subgraph::new();
+        let mut reference_path = None;
+        match query.query_type() {
+            QueryType::PathOffset(query_pos) => {
+                let result = subgraph.path_pos_from_gbz(&graph, &path_index, query_pos);
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+                reference_path = Some(result.unwrap());
+                let graph_pos = reference_path.as_ref().unwrap().0.graph_pos();
+                let result = subgraph.around_position(graph_pos, query.context, &mut |handle| {
+                    GBZRecord::from_gbz(&graph, handle).ok_or(format!("The graph does not contain handle {}", handle))
+                });
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+            }
+            QueryType::PathInterval((query_pos, len)) => {
+                let result = subgraph.path_pos_from_gbz(&graph, &path_index, query_pos);
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+                reference_path = Some(result.unwrap());
+                let start_pos = reference_path.as_ref().unwrap().0;
+                let result = subgraph.around_interval(start_pos, *len, query.context, &mut |handle| {
+                    GBZRecord::from_gbz(&graph, handle).ok_or(format!("The graph does not contain handle {}", handle))
+                });
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+            }
+            QueryType::Nodes(nodes) => {
+                let result = subgraph.around_nodes(nodes, query.context, &mut |handle| {
+                    GBZRecord::from_gbz(&graph, handle).ok_or(format!("The graph does not contain handle {}", handle))
+                });
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+            }
+        }
+
+        // We do not have paths yet.
+        assert_eq!(subgraph.paths(), 0, "Subgraph {} has paths", query);
+        let result = subgraph.extract_paths(reference_path, query.output());
+        if let Err(err) = result {
+            panic!("Path extraction for query {} failed: {}", query, err);
+        }
+        check_subgraph(&graph, &subgraph, &true_nodes, *path_count, &query.to_string());
+    }
+}
+
+#[test]
+fn manual_db_queries() {
+    let gbz_file = support::get_test_data("example.gbz");
+    let gbz_graph: GBZ = serialize::load_from(&gbz_file).unwrap();
+    let db_file = serialize::temp_file_name("subgraph-from-db");
+    let result = GBZBase::create_from_file(&gbz_file, &db_file);
+    assert!(result.is_ok(), "Failed to create database: {}", result.unwrap_err());
+    let mut database = GBZBase::open(&db_file).unwrap();
+    let mut graph = GraphInterface::new(&mut database).unwrap();
+
+    let (queries, truth) = queries_and_truth();
+    for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
+        let mut subgraph = Subgraph::new();
+        let mut reference_path = None;
+        match query.query_type() {
+            QueryType::PathOffset(query_pos) => {
+                let result = subgraph.path_pos_from_db(&mut graph, query_pos);
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+                reference_path = Some(result.unwrap());
+                let graph_pos = reference_path.as_ref().unwrap().0.graph_pos();
+                let result = subgraph.around_position(graph_pos, query.context, &mut |handle| {
+                    let record = graph.get_record(handle)?;
+                    record.ok_or(format!("The graph does not contain handle {}", handle))
+                });
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+            }
+            QueryType::PathInterval((query_pos, len)) => {
+                let result = subgraph.path_pos_from_db(&mut graph, query_pos);
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+                reference_path = Some(result.unwrap());
+                let start_pos = reference_path.as_ref().unwrap().0;
+                let result = subgraph.around_interval(start_pos, *len, query.context, &mut |handle| {
+                    let record = graph.get_record(handle)?;
+                    record.ok_or(format!("The graph does not contain handle {}", handle))
+                });
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+            }
+            QueryType::Nodes(nodes) => {
+                let result = subgraph.around_nodes(nodes, query.context, &mut |handle| {
+                    let record = graph.get_record(handle)?;
+                    record.ok_or(format!("The graph does not contain handle {}", handle))
+                });
+                if let Err(err) = result {
+                    panic!("Query {} failed: {}", query, err);
+                }
+            }
+        }
+
+        // We do not have paths yet.
+        assert_eq!(subgraph.paths(), 0, "Subgraph {} has paths", query);
+        let result = subgraph.extract_paths(reference_path, query.output());
+        if let Err(err) = result {
+            panic!("Path extraction for query {} failed: {}", query, err);
+        }
+        check_subgraph(&gbz_graph, &subgraph, &true_nodes, *path_count, &query.to_string());
     }
 
     drop(graph);


### PR DESCRIPTION
This turned out to be a full redesign of the `Subgraph` object and subgraph queries:

* You now create a new `Subgraph` object and update it:
  * With integrated `from_gbz` / `from_db` methods.
  * With lower-level operations followed by path extraction.
  * By adding/removing individual nodes followed by path extraction.
* The `Subgraph` object tries to reuse node records it has already extracted, making it useful as a sliding window over the graph / reference path.
* Paths must be extracted again after any changes to the subgraph, as preserving them would be complex and probably inefficient.
* There is also a basic graph interface for the subgraph similar to the node/edge part of the `GBZ` interface.
* Queries based on nodes and path intervals now handle the context properly, instead of extracting (context + length / 2) around the midpoint.
* Node based queries can also handle contexts around multiple nodes.