### PR TITLE
Split GAF-base queries into compact intervals

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Jouni Siren
+Copyright (c) 2023, 2024, 2025 Jouni Siren
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -726,6 +726,7 @@ impl Alignment {
         self.path = TargetPath::Path(path);
     }
 
+    // FIXME: Make this work with unaligned reads represented as insertions.
     /// Returns an iterator over the alignment as a sequence of mappings.
     ///
     /// Returns [`None`] if a valid iterator cannot be built.

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -76,13 +76,13 @@ fn extract_gaf(graph: GraphReference<'_, '_>, subgraph: &Subgraph, config: &Conf
     let read_set = ReadSet::new(graph, subgraph, &gaf_base, config.alignment_output)?;
     if config.alignment_output == AlignmentOutput::Clipped {
         eprintln!(
-            "Extracted {} fragments for {} reads in {} alignment blocks with {} node records",
-            read_set.len(), read_set.unclipped(), read_set.blocks(), read_set.node_records()
+            "Extracted {} fragments for {} reads in {} alignment blocks with {} node records in {} clusters",
+            read_set.len(), read_set.unclipped(), read_set.blocks(), read_set.node_records(), read_set.clusters()
         );
     } else {
         eprintln!(
-            "Extracted {} reads in {} alignment blocks with {} node records",
-            read_set.len(), read_set.blocks(), read_set.node_records()
+            "Extracted {} reads in {} alignment blocks with {} node records in {} clusters",
+            read_set.len(), read_set.blocks(), read_set.node_records(), read_set.clusters()
         );
     }
 


### PR DESCRIPTION
Minigraph–Cactus graphs contain some nodes with much larger identifiers than their neighbors. Regions like that did not work well when querying GAF-base. A relatively small subgraph could cover a large fraction of the node id range of a chromosome, forcing GAF-base to check a large number of reads outside the subgraph.

This PR fixes the issue by clustering the subgraph into compact node id ranges, where no gap between successive node ids is more than 3x the mean within the cluster. All ranges are queried separately and the results are combined when creating a `ReadSet`.