### PR TITLE
db2gaf tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gbz-base"
 version = "0.1.0"
-authors = ["Jouni Siren <jouni.siren@iki.fi>"]
 edition = "2024"
 description = "Pangenome file formats based on SQLite"
 license = "MIT"
@@ -11,6 +10,7 @@ repository = "https://github.com/jltsiren/gbz-base"
 [dependencies]
 gbwt = { git = "https://github.com/jltsiren/gbwt-rs", branch = "main" }
 simple-sds = { git = "https://github.com/jltsiren/simple-sds", branch = "main" }
+pggname = { git = "https://github.com/jltsiren/pggname", branch = "main" }
 rusqlite = { version = "0.37", features = ["bundled"] }
 getopts = { version = "0.2" }
 flate2 = { version = "1.0" }
@@ -28,6 +28,12 @@ doc = false
 
 [[bin]]
 name = "gaf2db"
+test = false
+bench = false
+doc = false
+
+[[bin]]
+name = "db2gaf"
 test = false
 bench = false
 doc = false

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## Current version
 
-* ...
+* `db2gaf` tool for converting a GAF-base back to GAF format.
 
 ## GBZ-base 0.1.0 (2025-11-06)
 

--- a/src/bin/db2gaf.rs
+++ b/src/bin/db2gaf.rs
@@ -1,0 +1,170 @@
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::time::Instant;
+use std::{env, io, process, thread};
+
+use gbwt::GBZ;
+
+use gbz_base::{GAFBase, ReadSet};
+
+use simple_sds::serialize;
+
+use getopts::Options;
+
+//-----------------------------------------------------------------------------
+
+fn main() -> Result<(), String> {
+    let start_time = Instant::now();
+
+    let config = Config::new();
+
+    // Inputs.
+    let database = GAFBase::open(&config.gaf_base_file)?;
+    let graph: GBZ = serialize::load_from(&config.gbz_file).map_err(|x| x.to_string())?;
+    
+    write_gaf(&database, &graph, &config)?;
+
+    let end_time = Instant::now();
+    let seconds = end_time.duration_since(start_time).as_secs_f64();
+    eprintln!("Used {:.3} seconds", seconds);
+
+    Ok(())
+}
+
+//-----------------------------------------------------------------------------
+
+fn write_gaf(database: &GAFBase, graph: &GBZ, config: &Config) -> Result<(), String> {
+    // Decoded ReadSets, with an empty ReadSet signaling the end of input.
+    let (to_output, from_decoder) = mpsc::sync_channel(4);
+
+    // Status of the output thread as Result<(), String>.
+    let (to_decoder, from_output) = mpsc::sync_channel(1);
+
+    // Output thread.
+    let output_thread = thread::spawn(move || {
+        let mut output = io::stdout();
+        loop {
+            let read_set: ReadSet = from_decoder.recv().unwrap_or(ReadSet::default());
+            if read_set.is_empty() {
+                let _ = to_decoder.send(Ok(()));
+                break;
+            }
+            let result = read_set.to_gaf(&mut output);
+            if result.is_err() {
+                let _ = to_decoder.send(result);
+                break;
+            }
+        }
+    });
+
+    let mut found_alns = 0;
+    let mut rowid = 1; // SQLite row ids start from 1.
+    let mut status = Ok(());
+    while found_alns < database.alignments() {
+        let range = rowid..(rowid + config.chunk_size);
+        let read_set = ReadSet::from_rows(database, range.clone(), graph);
+        if read_set.is_err() {
+            status = Err(read_set.unwrap_err());
+            let _ = to_output.send(ReadSet::default()); // Signal end of input.
+            break;
+        }
+        let read_set = read_set.unwrap();
+        if read_set.is_empty() {
+            status = Err(format!("No reads found in rows {}..{}", range.start, range.end));
+            let _ = to_output.send(ReadSet::default()); // Signal end of input.
+            break;
+        }
+        found_alns += read_set.len();
+        let _ = to_output.send(read_set);
+        rowid += config.chunk_size;
+    }
+    if status.is_ok() {
+        let _ = to_output.send(ReadSet::default()); // Signal end of input.
+        if found_alns != database.alignments() {
+            status = Err(format!("Expected {} alignments, but found {}", database.alignments(), found_alns));
+        }
+    }
+
+    // Wait for the output thread to finish.
+    let output_result = from_output.recv().unwrap_or(Ok(()));
+    let _ = output_thread.join();
+    if output_result.is_err() {
+        return output_result;
+    }
+
+    status
+}
+
+//-----------------------------------------------------------------------------
+
+struct Config {
+    gaf_base_file: PathBuf,
+    gbz_file: PathBuf,
+    chunk_size: usize,
+}
+
+impl Config {
+    // Default number of blocks in a single ReadSet.
+    const CHUNK_SIZE: usize = 10;
+
+    pub fn new() -> Config {
+        let args: Vec<String> = env::args().collect();
+        let program = args[0].clone();
+        let header = format!("Usage: {} [options] -r graph.gbz gaf_base.db > output.gaf", program);
+
+        let mut opts = Options::new();
+        opts.optflag("h", "help", "print this help");
+        opts.optopt("r", "reference", "use this GBZ graph as the reference", "FILE");
+        opts.optopt("c", "chunk-size", "chunk size in blocks (default: 10)", "INT");
+        let matches = match opts.parse(&args[1..]) {
+            Ok(m) => m,
+            Err(f) => {
+                eprintln!("{}", f);
+                process::exit(1);
+            }
+        };
+
+        // Parse options.
+        if matches.opt_present("h") {
+            eprint!("{}", opts.usage(&header));
+            process::exit(0);
+        }
+        let gaf_base_file = if let Some(s) = matches.free.first() {
+            PathBuf::from(s)
+        } else {
+            eprint!("{}", opts.usage(&header));
+            process::exit(1);
+        };
+        let gbz_file = if let Some(s) = matches.opt_str("r") {
+            PathBuf::from(s)
+        } else {
+            eprint!("{}", opts.usage(&header));
+            process::exit(1);
+        };
+        let chunk_size = if let Some(s) = matches.opt_str("c") {
+            match s.parse::<usize>() {
+                Ok(x) => x,
+                Err(e) => {
+                    eprintln!("Failed to parse --chunk-size: {}", e);
+                    process::exit(1);
+                }
+            }
+        } else {
+            Config::CHUNK_SIZE
+        };
+
+        // Validate options.
+        if chunk_size < 1 {
+            eprintln!("--chunk-size must be positive");
+            process::exit(1);
+        }
+
+        Config {
+            gaf_base_file,
+            gbz_file,
+            chunk_size,
+        }
+    }
+}
+
+//-----------------------------------------------------------------------------

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -31,8 +31,8 @@ fn main() -> Result<(), String> {
     // Statistics.
     let database = GAFBase::open(&config.db_file)?;
     eprintln!(
-        "The database contains {} nodes and {} alignments",
-        database.nodes(), database.alignments()
+        "The database contains {} nodes and {} alignments in {} blocks",
+        database.nodes(), database.alignments(), database.blocks()
     );
     let size = database.file_size().unwrap_or(String::from("unknown"));
     eprintln!("Final database size: {}", size);

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -450,9 +450,10 @@ fn index_reference_paths() {
 
 // Helper functions for GAF-base tests.
 
-fn check_gaf_base(db: &GAFBase, nodes: usize, alignments: usize, bidirectional_gbwt: bool) {
+fn check_gaf_base(db: &GAFBase, nodes: usize, alignments: usize, rows: usize, bidirectional_gbwt: bool) {
     assert_eq!(db.nodes(), nodes, "Wrong number of nodes in GAF-base database");
     assert_eq!(db.alignments(), alignments, "Wrong number of alignments in GAF-base database");
+    assert_eq!(db.blocks(), rows, "Wrong number of blocks in GAF-base database");
     assert_eq!(db.bidirectional_gbwt(), bidirectional_gbwt, "Wrong GBWT bidirectionality in GAF-base database");
 }
 
@@ -460,11 +461,16 @@ fn check_gaf_base(db: &GAFBase, nodes: usize, alignments: usize, bidirectional_g
 
 // Tests for GAF-base.
 
+const UNIDIRECTIONAL_NODES: usize = 2291;
+const BIDIRECTIONAL_NODES: usize = 2324;
+const ALIGNMENTS: usize = 12439;
+const BLOCKS: usize = 14; // 1000 reads/block, with unaligned reads as a separate block.
+
 #[test]
 fn gaf_base_empty() {
     let db_file = internal::create_gaf_base("empty.gaf", "empty.gbwt");
     let db = internal::open_gaf_base(&db_file);
-    check_gaf_base(&db, 0, 0, true);
+    check_gaf_base(&db, 0, 0, 0, true);
 
     drop(db);
     let _ = std::fs::remove_file(&db_file);
@@ -474,7 +480,7 @@ fn gaf_base_empty() {
 fn gaf_base_plain_unidirectional() {
     let db_file = internal::create_gaf_base("micb-kir3dl1_HG003.gaf", "micb-kir3dl1_HG003.gbwt");
     let db = internal::open_gaf_base(&db_file);
-    check_gaf_base(&db, 2291, 12439, false);
+    check_gaf_base(&db, UNIDIRECTIONAL_NODES, ALIGNMENTS, BLOCKS, false);
 
     drop(db);
     let _ = std::fs::remove_file(&db_file);
@@ -484,7 +490,7 @@ fn gaf_base_plain_unidirectional() {
 fn gaf_base_plain_bidirectional() {
     let db_file = internal::create_gaf_base("micb-kir3dl1_HG003.gaf", "bidirectional.gbwt");
     let db = internal::open_gaf_base(&db_file);
-    check_gaf_base(&db, 2324, 12439, true);
+    check_gaf_base(&db, BIDIRECTIONAL_NODES, ALIGNMENTS, BLOCKS, true);
 
     drop(db);
     let _ = std::fs::remove_file(&db_file);
@@ -494,7 +500,7 @@ fn gaf_base_plain_bidirectional() {
 fn gaf_base_gz_unidirectional() {
     let db_file = internal::create_gaf_base("micb-kir3dl1_HG003.gaf.gz", "micb-kir3dl1_HG003.gbwt");
     let db = internal::open_gaf_base(&db_file);
-    check_gaf_base(&db, 2291, 12439, false);
+    check_gaf_base(&db, UNIDIRECTIONAL_NODES, ALIGNMENTS, BLOCKS, false);
 
     drop(db);
     let _ = std::fs::remove_file(&db_file);
@@ -504,7 +510,7 @@ fn gaf_base_gz_unidirectional() {
 fn gaf_base_gz_bidirectional() {
     let db_file = internal::create_gaf_base("micb-kir3dl1_HG003.gaf.gz", "bidirectional.gbwt");
     let db = internal::open_gaf_base(&db_file);
-    check_gaf_base(&db, 2324, 12439, true);
+    check_gaf_base(&db, BIDIRECTIONAL_NODES, ALIGNMENTS, BLOCKS, true);
 
     drop(db);
     let _ = std::fs::remove_file(&db_file);


### PR DESCRIPTION
`db2gaf` tool for extracting the entire GAF file from a GAF-base. It uses a GBZ graph as a reference and does decompression and GAF output in separate threads. On my laptop, it decompressed the 40x Illumina test file in 30 minutes, while using 3 bgzip threads for compressing the output.

Also adds `ReadSet::from_rows` constructor for decompressing alignments by database row id ranges.