### PR TITLE
GAF-base version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Reference-free GAF-bases can be used without a reference graph.
 
 If quality strings are not required, it is possible to drop them with option `--no-quality`.
 This will make the database much smaller, particularly with long reads.
+Similarly, optional fields not supported directly by GAF-base can be dropped with option `--no-optional`.
 
 ## Subgraph queries
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Options `--output` and `--overwrite` are the same as in GBZ-base construction.
 The default block size (1000 alignments) is appropriate for short reads.
 When building a database of long read alignments, it can be changed with `--block-size N` (e.g. `--block-size 10` for 20 kbp reads).
 
+The default GAF-base is reference-based, like the GAF format itself.
+The alignments can only be decoded by using the corresponding GBZ graph or GBZ-base.
+FIXME: reference-free GAF-base.
+
+If quality strings are not required, it is possible to drop them with option `--no-quality`.
+This will make the database much smaller, particularly with long reads.
+
 ## Subgraph queries
 
 The `query` tool supports extracting subgraphs from a database or a GBZ graph.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ When building a database of long read alignments, it can be changed with `--bloc
 
 The default GAF-base is reference-based, like the GAF format itself.
 The alignments can only be decoded by using the corresponding GBZ graph or GBZ-base.
-FIXME: reference-free GAF-base.
+
+A reference-free GAF-base can be built by providing a reference graph during construction with option `--ref-free graph`.
+The graph file should be a GBZ graph.
+A GBZ-base can also be used, but the construction will be much slower.
+Reference-free GAF-bases can be used without a reference graph.
 
 If quality strings are not required, it is possible to drop them with option `--no-quality`.
 This will make the database much smaller, particularly with long reads.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,7 @@
 * GAF-base version 3:
   * More space-efficient representation of numerical values in table `Alignments`.
   * Database construction parameters stored in table `Tags`.
+  * Option to store sequences in table `Nodes` for reference-free use.
 
 ## GBZ-base 0.2.0 (2025-12-26)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,8 @@
 * GAF-base version 3:
   * More space-efficient representation of numerical values in table `Alignments`.
   * Database construction parameters stored in table `Tags`.
-  * Option to store sequences in table `Nodes` for reference-free use.
+  * Reference-free GAF-base with an option to store sequences in table `Nodes`.
+  * Option to leave out base quality strings.
 
 ## GBZ-base 0.2.0 (2025-12-26)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,11 @@
 
 ## Current version
 
+* Database versions: GBZ-base v0.4.0, GAF-base version 3
 * Support for GBZ version 2 with Zstandard compressed sequences.
+* GAF-base version 3:
+  * More space-efficient representation of numerical values in table `Alignments`.
+  * Database construction parameters stored in table `Tags`.
 
 ## GBZ-base 0.2.0 (2025-12-26)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,7 @@
 * GAF-base version 3:
   * More space-efficient representation of numerical values in table `Alignments`.
   * Database construction parameters stored in table `Tags`.
-  * Reference-free GAF-base with an option to store sequences in table `Nodes`.
+  * Optional reference-free GAF-base by storing node sequences in table `Nodes`.
   * Option to leave out base quality strings.
 
 ## GBZ-base 0.2.0 (2025-12-26)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@
   * Database construction parameters stored in table `Tags`.
   * Optional reference-free GAF-base by storing node sequences in table `Nodes`.
   * Option to leave out base quality strings.
+  * Also stores unknown optional fields, unless told otherwise.
 
 ## GBZ-base 0.2.0 (2025-12-26)
 

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -1476,6 +1476,7 @@ impl AlignmentBlock {
         Self::zstd_compress(&quality_strings)
     }
 
+    // TODO: Instead of TAG:TYPE:VALUE, we could drop the separators.
     fn compress_optional_fields(alignments: &[Alignment]) -> Result<Vec<u8>, String> {
         let mut optional: Vec<u8> = Vec::new();
         for aln in alignments.iter() {

--- a/src/alignment/tests.rs
+++ b/src/alignment/tests.rs
@@ -242,7 +242,9 @@ fn alignment_known_bad() {
 fn alignment_default() {
     let default = Alignment::default();
     assert!(default.is_unaligned(), "A default alignment should be unaligned");
-    assert!(!default.is_perfect(), "An empty alignment should not be perfect");
+    assert!(!default.is_full(), "A default alignment should not be a full alignment");
+    assert!(!default.is_exact(), "An empty alignment should not be exact");
+    assert!(!default.has_difference_string(), "A default alignment should not have a difference string");
 
     assert!(default.name.is_empty(), "A default alignment should not have a name");
     assert_eq!(default.seq_len, 0, "A default alignment should have a sequence length of 0");
@@ -257,7 +259,7 @@ fn alignment_default() {
     assert!(default.mapq.is_none(), "A default alignment should not have a mapping quality");
     assert!(default.score.is_none(), "A default alignment should not have a score");
     assert!(default.base_quality.is_empty(), "A default alignment should not have base quality values");
-    assert!(default.difference.is_empty(), "A default alignment should not have a difference string");
+    assert!(default.difference.is_empty(), "A default alignment should have an empty difference string");
     assert!(default.pair.is_none(), "A default alignment should not have a paired read");
     assert!(default.optional.is_empty(), "A default alignment should not have any optional fields");
 }
@@ -272,7 +274,9 @@ fn alignment_operations() {
     aln.matches = 10;
 
     assert!(!aln.is_unaligned(), "The alignment should be aligned");
-    assert!(aln.is_perfect(), "The alignment should be perfect");
+    assert!(aln.is_full(), "The alignment should be full");
+    assert!(aln.is_exact(), "The alignment should be exact");
+    assert!(!aln.has_difference_string(), "The alignment should not have a difference string");
 
     // Various ways of making the alignment imperfect.
     {
@@ -280,20 +284,20 @@ fn alignment_operations() {
         wrong_start.seq_interval.start += 1;
         wrong_start.path_interval.start += 1;
         wrong_start.matches -= 1;
-        assert!(!wrong_start.is_perfect(), "An alignment starting after query start should not be perfect");
+        assert!(!wrong_start.is_full(), "An alignment starting after query start should not be full");
     }
     {
         let mut wrong_end = aln.clone();
         wrong_end.seq_interval.end -= 1;
         wrong_end.path_interval.end -= 1;
         wrong_end.matches -= 1;
-        assert!(!wrong_end.is_perfect(), "An alignment ending before query end should not be perfect");
+        assert!(!wrong_end.is_full(), "An alignment ending before query end should not be full");
     }
     {
         let mut has_edits = aln.clone();
         has_edits.matches -= 1;
         has_edits.edits += 1;
-        assert!(!has_edits.is_perfect(), "An alignment with edits should not be perfect");
+        assert!(!has_edits.is_exact(), "An alignment with edits should not be exact");
     }
 
     // We have a GBWT start position.

--- a/src/alignment/tests.rs
+++ b/src/alignment/tests.rs
@@ -384,13 +384,8 @@ fn check_encode_decode(block: &[Alignment], index: &GBWT, first_id: usize) {
 fn integration_test(gaf_file: &'static str, gbwt_file: &'static str, block_size: usize) {
     // Parse the alignments.
     let gaf_file = utils::get_test_data(gaf_file);
-    let mut alignments = parse_alignments(&gaf_file, false);
+    let alignments = parse_alignments(&gaf_file, false);
     assert_eq!(alignments.len(), 12439, "Unexpected number of parsed alignments");
-
-    // Remove the optional fields as we do not encode them for now.
-    for aln in &mut alignments {
-        aln.optional.clear();
-    }
 
     // Load the GBWT index.
     let gbwt_file = utils::get_test_data(gbwt_file);

--- a/src/alignment/tests.rs
+++ b/src/alignment/tests.rs
@@ -368,6 +368,10 @@ fn check_encode_decode(block: &[Alignment], index: &GBWT, first_id: usize) {
 
     for (i, aln) in decoded.iter_mut().enumerate() {
         aln.extract_target_path(index);
+        // NOTE: We do not store the true target path length in the alignment block.
+        // Because we do not have the reference graph here, we simply assume that it is correct.
+        assert_eq!(aln.path_len, aln.path_interval.end, "Non-zero right flank for target path of alignment {} in decoded block {}..{}", i, range.start, range.end);
+        aln.path_len = block[i].path_len;
         assert_eq!(*aln, block[i], "Wrong alignment {} in the decoded block {}..{}", range.start + i, range.start, range.end);
     }
 }

--- a/src/bin/db2gaf.rs
+++ b/src/bin/db2gaf.rs
@@ -161,11 +161,7 @@ impl Config {
             eprint!("{}", opts.usage(&header));
             process::exit(1);
         };
-        let gbz_file = if let Some(s) = matches.opt_str("r") {
-            Some(PathBuf::from(s))
-        } else {
-            None
-        };
+        let gbz_file = matches.opt_str("r").map(PathBuf::from);
         let chunk_size = if let Some(s) = matches.opt_str("c") {
             match s.parse::<usize>() {
                 Ok(x) => x,

--- a/src/bin/db2gaf.rs
+++ b/src/bin/db2gaf.rs
@@ -17,6 +17,8 @@ use getopts::Options;
 
 //-----------------------------------------------------------------------------
 
+// FIXME: Make the graph optional in case the GAF-base contains sequences.
+
 fn main() -> Result<(), String> {
     let start_time = Instant::now();
 
@@ -36,7 +38,7 @@ fn main() -> Result<(), String> {
         process::exit(1);
     }
 
-    write_gaf(&database, &alignments, &graph, &config)?;
+    write_gaf(&database, &alignments, Some(&graph), &config)?;
 
     let end_time = Instant::now();
     let seconds = end_time.duration_since(start_time).as_secs_f64();
@@ -47,7 +49,7 @@ fn main() -> Result<(), String> {
 
 //-----------------------------------------------------------------------------
 
-fn write_gaf(database: &GAFBase, alignments: &GraphName, graph: &GBZ, config: &Config) -> Result<(), String> {
+fn write_gaf(database: &GAFBase, alignments: &GraphName, graph: Option<&GBZ>, config: &Config) -> Result<(), String> {
     // Decoded ReadSets, with an empty ReadSet signaling the end of input.
     let (to_output, from_decoder) = mpsc::sync_channel(4);
 

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -104,7 +104,8 @@ impl Config {
         opts.optopt("r", "ref-free", "build a reference-free GAF-base using this graph", "FILE");
         let block_desc = format!("number of alignments per block (default: {})", params.block_size);
         opts.optopt("b", "block-size", &block_desc, "INT");
-        opts.optflag("q", "no-quality", "do not store quality strings");
+        opts.optflag("", "no-quality", "do not store quality strings");
+        opts.optflag("", "no-optional", "do not store unsupported optional fields");
         opts.optopt("o", "output", "output file name (default: <input>.db)", "FILE");
         opts.optflag("", "overwrite", "overwrite the database file if it exists");
         let matches = match opts.parse(&args[1..]) {
@@ -158,8 +159,11 @@ impl Config {
                 }
             }
         }
-        if matches.opt_present("q") {
+        if matches.opt_present("no-quality") {
             params.store_quality_strings = false;
+        }
+        if matches.opt_present("no-optional") {
+            params.store_optional_fields = false;
         }
 
         let overwrite = matches.opt_present("overwrite");

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -2,14 +2,18 @@ use std::path::PathBuf;
 use std::time::Instant;
 use std::{env, fs, process};
 
+use gbz_base::{GBZBase, GraphInterface};
 use gbz_base::{GAFBase, GAFBaseParams, GraphReference};
-use gbz_base::utils;
+use gbz_base::db::FileType;
+use gbz_base::{db, utils};
+
+use gbz::GBZ;
+
+use simple_sds::serialize;
 
 use getopts::Options;
 
 //-----------------------------------------------------------------------------
-
-// FIXME: An option to store node sequences by providing a graph.
 
 fn main() -> Result<(), String> {
     let start_time = Instant::now();
@@ -28,7 +32,36 @@ fn main() -> Result<(), String> {
     }
 
     // Create the database.
-    GAFBase::create_from_files(&config.gaf_file, &config.gbwt_file, &config.db_file, GraphReference::None, &config.params)?;
+    if let Some(graph_file) = &config.graph_file {
+        match db::identify_file(graph_file) {
+            FileType::Gbz => {
+                eprintln!("Loading GBZ graph {}", graph_file.display());
+                let graph: GBZ = serialize::load_from(graph_file).map_err(|x| x.to_string())?;
+                GAFBase::create_from_files(
+                    &config.gaf_file, &config.gbwt_file, &config.db_file,
+                    GraphReference::Gbz(&graph), &config.params
+                )?;
+            },
+            FileType::Version(v) => {
+                if v != GBZBase::VERSION {
+                    let msg = format!("File {} is {}; expected {}", graph_file.display(), v, GBZBase::VERSION);
+                    return Err(msg);
+                }
+                eprintln!("Opening GBZ-base {}", graph_file.display());
+                let database = GBZBase::open(graph_file)?;
+                let mut graph = GraphInterface::new(&database)?;
+                GAFBase::create_from_files(
+                    &config.gaf_file, &config.gbwt_file, &config.db_file,
+                    GraphReference::Db(&mut graph), &config.params
+                )?;
+            },
+            _ => {
+                return Err(format!("File {} is not a valid graph", graph_file.display()));
+            }
+        };
+    } else {
+        GAFBase::create_from_files(&config.gaf_file, &config.gbwt_file, &config.db_file, GraphReference::None, &config.params)?;
+    }
 
     // Statistics.
     let database = GAFBase::open(&config.db_file)?;
@@ -51,6 +84,7 @@ fn main() -> Result<(), String> {
 struct Config {
     pub gaf_file: PathBuf,
     pub gbwt_file: PathBuf,
+    pub graph_file: Option<PathBuf>,
     pub db_file: PathBuf,
     pub overwrite: bool,
     pub params: GAFBaseParams,
@@ -67,6 +101,7 @@ impl Config {
         let mut opts = Options::new();
         opts.optflag("h", "help", "print this help");
         opts.optopt("g", "gbwt", "GBWT file name (required)", "FILE");
+        opts.optopt("r", "ref-free", "build a reference-free GAF-base using this graph", "FILE");
         let block_desc = format!("number of alignments per block (default: {})", params.block_size);
         opts.optopt("b", "block-size", &block_desc, "INT");
         opts.optflag("q", "no-quality", "do not store quality strings");
@@ -90,6 +125,12 @@ impl Config {
         } else {
             eprint!("{}", opts.usage(&header));
             process::exit(1);
+        };
+        let graph_file = if let Some(s) = matches.opt_str("r") {
+            params.reference_free = true;
+            Some(PathBuf::from(s))
+        } else {
+            None
         };
         if let Some(s) = matches.opt_str("o") {
             db_file = Some(PathBuf::from(s));
@@ -124,7 +165,7 @@ impl Config {
         let overwrite = matches.opt_present("overwrite");
 
         Config {
-            gaf_file, gbwt_file,
+            gaf_file, gbwt_file, graph_file,
             db_file: db_file.unwrap(),
             overwrite,
             params,

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -10,6 +10,7 @@ use getopts::Options;
 //-----------------------------------------------------------------------------
 
 // FIXME: An option to store node sequences by providing a graph.
+// FIXME: Also check that the graph and the GAF match by pggname.
 
 fn main() -> Result<(), String> {
     let start_time = Instant::now();

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -2,12 +2,15 @@ use std::path::PathBuf;
 use std::time::Instant;
 use std::{env, fs, process};
 
-use gbz_base::{GAFBase, GAFBaseParams};
+use gbz_base::{GAFBase, GAFBaseParams, GraphReference};
 use gbz_base::utils;
 
 use getopts::Options;
 
 //-----------------------------------------------------------------------------
+
+// FIXME: An option to store node sequences by providing a graph.
+// FIXME: An option to not store quality strings.
 
 fn main() -> Result<(), String> {
     let start_time = Instant::now();
@@ -26,7 +29,7 @@ fn main() -> Result<(), String> {
     }
 
     // Create the database.
-    GAFBase::create_from_files(&config.gaf_file, &config.gbwt_file, &config.db_file, &config.params)?;
+    GAFBase::create_from_files(&config.gaf_file, &config.gbwt_file, &config.db_file, GraphReference::None, &config.params)?;
 
     // Statistics.
     let database = GAFBase::open(&config.db_file)?;

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -10,7 +10,6 @@ use getopts::Options;
 //-----------------------------------------------------------------------------
 
 // FIXME: An option to store node sequences by providing a graph.
-// FIXME: Also check that the graph and the GAF match by pggname.
 
 fn main() -> Result<(), String> {
     let start_time = Instant::now();

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -10,7 +10,6 @@ use getopts::Options;
 //-----------------------------------------------------------------------------
 
 // FIXME: An option to store node sequences by providing a graph.
-// FIXME: An option to not store quality strings.
 
 fn main() -> Result<(), String> {
     let start_time = Instant::now();
@@ -70,6 +69,7 @@ impl Config {
         opts.optopt("g", "gbwt", "GBWT file name (required)", "FILE");
         let block_desc = format!("number of alignments per block (default: {})", params.block_size);
         opts.optopt("b", "block-size", &block_desc, "INT");
+        opts.optflag("q", "no-quality", "do not store quality strings");
         opts.optopt("o", "output", "output file name (default: <input>.db)", "FILE");
         opts.optflag("", "overwrite", "overwrite the database file if it exists");
         let matches = match opts.parse(&args[1..]) {
@@ -102,8 +102,9 @@ impl Config {
             process::exit(1);
         };
         if db_file.is_none() {
-            // TODO: add_extension is still experimental
-            db_file = Some(PathBuf::from(format!("{}.db", gaf_file.display())));
+            let mut name = gaf_file.clone();
+            name.add_extension("db");
+            db_file = Some(name);
         }
 
         // Parameters.
@@ -115,6 +116,9 @@ impl Config {
                     process::exit(1);
                 }
             }
+        }
+        if matches.opt_present("q") {
+            params.store_quality_strings = false;
         }
 
         let overwrite = matches.opt_present("overwrite");

--- a/src/bin/gbz2db.rs
+++ b/src/bin/gbz2db.rs
@@ -93,8 +93,9 @@ impl Config {
             process::exit(1);
         };
         if db_file.is_none() {
-            // TODO: add_extension is still experimental
-            db_file = Some(PathBuf::from(format!("{}.db", gbz_file.display())));
+            let mut name = gbz_file.clone();
+            name.add_extension("db");
+            db_file = Some(name);
         }
 
         let overwrite = matches.opt_present("overwrite");

--- a/src/db.rs
+++ b/src/db.rs
@@ -756,6 +756,9 @@ impl Default for GAFBaseParams {
 // other path visits to that node. If a path is the (i+1)-th path starting from GBWT node v,
 // the GBWT starting position is (v, i).
 
+// TODO: If we are willing to use a reference, we could reuse `edges` in the `Nodes` table from it.
+// We can similarly speed up GBWT construction by having the GBWT of the graph available.
+
 // FIXME: Option to create with optional fields
 // FIXME: tests for GAF-base with sequences; without quality strings
 /// Creating the database.
@@ -900,6 +903,8 @@ impl GAFBase {
         eprintln!("Inserting nodes");
 
         // Create the nodes table.
+        // In a reference-based GAF-base, `sequence` will be empty.
+        // In a reference-free GAF-base, it will store node sequences.
         connection.execute(
             "CREATE TABLE Nodes (
                 handle INTEGER PRIMARY KEY,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1688,7 +1688,7 @@ impl<'reference, 'graph> GraphReference<'reference, 'graph> {
             GraphReference::Db(db) => {
                 db.get_record(handle)?.ok_or_else(|| format!("The graph does not contain handle {}", handle))
             },
-            GraphReference::None => Err(String::from("No graph reference provided")),
+            GraphReference::None => Err(String::from("No reference graph provided")),
         }
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -519,9 +519,9 @@ impl GAFBase {
     // Key for database version.
     const KEY_VERSION: &'static str = "version";
 
-    // FIXME: "GAF-base version 3-dev" during development, "GAF-base version 3" for release
+    // FIXME: "GAF-base version 3" for release
     /// Current database version.
-    pub const VERSION: &'static str = "GAF-base v0.2.0";
+    pub const VERSION: &'static str = "GAF-base version 3-dev-1";
 
     // Key for node count.
     const KEY_NODES: &'static str = "nodes";
@@ -880,10 +880,10 @@ impl GAFBase {
         let mut gaf_file = gaf_file;
         let mut connection = connection;
 
-        // FIXME: make rowid an explicit primary key
         // FIXME: set everything except min_handle, max_handle, read_length NOT NULL
         connection.execute(
             "CREATE TABLE Alignments (
+                id INTEGER PRIMARY KEY,
                 min_handle INTEGER,
                 max_handle INTEGER CHECK (min_handle <= max_handle),
                 alignments INTEGER NOT NULL,

--- a/src/db.rs
+++ b/src/db.rs
@@ -756,8 +756,8 @@ impl Default for GAFBaseParams {
 // other path visits to that node. If a path is the (i+1)-th path starting from GBWT node v,
 // the GBWT starting position is (v, i).
 
-// FIXME: Option to create without quality strings; with optional fields
-// FIXME: tests with a GAF-base with sequences
+// FIXME: Option to create with optional fields
+// FIXME: tests for GAF-base with sequences; without quality strings
 /// Creating the database.
 impl GAFBase {
     /// Creates a new database from the [`GBWT`] index in file `gbwt_file` and stores the database in file `db_file`.
@@ -1104,6 +1104,10 @@ impl GAFBase {
             );
             match aln {
                 Ok(aln) => {
+                    let mut aln = aln;
+                    if !params.store_quality_strings {
+                        aln.base_quality.clear();
+                    }
                     if aln.is_unaligned() != unaligned_block {
                         // We have a new block.
                         if !block.is_empty() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -703,7 +703,7 @@ pub struct GAFBaseParams {
     /// Build a reference-free GAF-base that stores sequences in table `Nodes`.
     ///
     /// Default: `false`.
-    pub store_sequences: bool,
+    pub reference_free: bool,
 
     /// Store base quality strings for the alignments.
     ///
@@ -723,8 +723,8 @@ impl GAFBaseParams {
     /// Returns a JSON description of the parameters that can be stored as a tag.
     pub fn to_json(&self) -> String {
         let mut fields = Vec::new();
-        if self.store_sequences {
-            fields.push(JSONValue::String(String::from("sequences")));
+        if self.reference_free {
+            fields.push(JSONValue::String(String::from("reference_free")));
         }
         if self.store_quality_strings {
             fields.push(JSONValue::String(String::from("quality_strings")));
@@ -745,7 +745,7 @@ impl Default for GAFBaseParams {
     fn default() -> Self {
         Self {
             block_size: Self::BLOCK_SIZE,
-            store_sequences: false,
+            reference_free: false,
             store_quality_strings: true,
             store_optional_fields: false,
         }
@@ -837,7 +837,7 @@ impl GAFBase {
 
         // We will only use the graph if we actually need it.
         let mut graph = graph;
-        if params.store_sequences {
+        if params.reference_free {
             if graph.is_none() {
                 return Err(String::from("The construction of a reference-free GAF-base requires a graph"));
             }

--- a/src/db.rs
+++ b/src/db.rs
@@ -521,7 +521,7 @@ impl GAFBase {
 
     // FIXME: "GAF-base version 3" for release
     /// Current database version.
-    pub const VERSION: &'static str = "GAF-base version 3-dev-1";
+    pub const VERSION: &'static str = "GAF-base version 3-dev-2";
 
     // Key for node count.
     const KEY_NODES: &'static str = "nodes";
@@ -688,7 +688,7 @@ impl AlignmentStats {
     }
 }
 
-// FIXME: store sequences, store quality strings
+// FIXME: store sequences, store quality strings, store optional fields
 // FIXME: to tag
 /// GAF-base construction parameters.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -697,14 +697,17 @@ pub struct GAFBaseParams {
     ///
     /// Default: [`Self::BLOCK_SIZE`].
     pub block_size: usize,
-    /// Store sequences in table `Nodes`, allowing queries without a reference graph.
+
+    /// Build a reference-free GAF-base that stores sequences in table `Nodes`.
     ///
     /// Default: `false`.
     pub store_sequences: bool,
+
     /// Store base quality strings for the alignments.
     ///
     /// Default: `true`.
     pub store_quality_strings: bool,
+
     /// Store unknown optional fields with the alignments.
     ///
     /// Default: `false`.
@@ -774,12 +777,13 @@ impl GAFBase {
     /// * `gaf_file`: GAF file storing the alignments. Can be gzip-compressed.
     /// * `gbwt_file`: GBWT file storing the target paths.
     /// * `db_file`: Output database file.
-    /// * `graph`: A GBZ-compatible graph, or [`GraphReference::None`] if node sequences will not be stored.
+    /// * `graph`: A GBZ-compatible graph for building a reference-free database, or [`GraphReference::None`] for a reference-based one.
     /// * `params`: Construction parameters.
     ///
     /// # Errors
     ///
     /// Returns an error if the input files do not exist or the database already exists.
+    /// Returns an error if trying to build a reference-free GAF-base without a graph.
     /// Passes through any database errors.
     pub fn create_from_files(
         gaf_file: &Path, gbwt_file: &Path, db_file: &Path,
@@ -802,12 +806,13 @@ impl GAFBase {
     /// * `gaf_file`: GAF file storing the alignments. Can be gzip-compressed.
     /// * `index`: GBWT index storing the target paths.
     /// * `db_file`: Output database file.
-    /// * `graph`: A GBZ-compatible graph, or [`GraphReference::None`] if node sequences will not be stored.
+    /// * `graph`: A GBZ-compatible graph for building a reference-free database, or [`GraphReference::None`] for a reference-based one.
     /// * `params`: Construction parameters.
     ///
     /// # Errors
     ///
     /// Returns an error if the GAF file does not exist or if the database already exists.
+    /// Returns an error if trying to build a reference-free GAF-base without a graph.
     /// Passes through any database errors.
     pub fn create<P: AsRef<Path>, Q: AsRef<Path>>(
         gaf_file: P, index: Arc<GBWT>, db_file: Q,
@@ -823,7 +828,7 @@ impl GAFBase {
         let mut graph = graph;
         if params.store_sequences {
             if graph.is_none() {
-                return Err(String::from("Node sequences cannot be stored without a graph"));
+                return Err(String::from("The construction of a reference-free GAF-base requires a graph"));
             }
         } else {
             graph = GraphReference::None;

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -459,7 +459,7 @@ fn check_gaf_base(db: &GAFBase, nodes: usize, alignments: usize, rows: usize, bi
 
 fn check_gaf_base_tags(db: &GAFBase, name_tags: usize) {
     let tags = db.tags();
-    let expected_tags = 4 + name_tags; // version, nodes, alignments, bidirectional
+    let expected_tags = 5 + name_tags; // version, nodes, alignments, bidirectional, params
     assert_eq!(tags.len(), expected_tags, "Wrong number of tags in GAF-base database");
     if name_tags > 0 {
         let graph_name = GraphName::from_tags(&tags);

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -533,5 +533,61 @@ fn gaf_base_gz_bidirectional() {
     let _ = std::fs::remove_file(&db_file);
 }
 
+#[test]
+fn gaf_base_no_quality() {
+    let mut params = GAFBaseParams::default();
+    params.store_quality_strings = false;
+
+    let db_file = internal::create_gaf_base_with_params(
+        "micb-kir3dl1_HG003.gaf", "micb-kir3dl1_HG003.gbwt",
+        GraphReference::None, &params
+    );
+    let db = internal::open_gaf_base(&db_file);
+    check_gaf_base(&db, UNIDIRECTIONAL_NODES, ALIGNMENTS, BLOCKS, false);
+    check_gaf_base_tags(&db, 1);
+
+    drop(db);
+    let _ = std::fs::remove_file(&db_file);
+}
+
+#[test]
+fn gaf_base_ref_free() {
+    let gbz_file = utils::get_test_data("micb-kir3dl1.gbz");
+    let graph: GBZ = serialize::load_from(&gbz_file).unwrap();
+
+    let db_file = internal::create_gaf_base_with_params(
+        "micb-kir3dl1_HG003.gaf", "micb-kir3dl1_HG003.gbwt",
+        GraphReference::Gbz(&graph), &GAFBaseParams::default()
+    );
+    let db = internal::open_gaf_base(&db_file);
+    check_gaf_base(&db, UNIDIRECTIONAL_NODES, ALIGNMENTS, BLOCKS, false);
+    check_gaf_base_tags(&db, 1);
+
+    drop(db);
+    let _ = std::fs::remove_file(&db_file);
+}
+
+#[test]
+fn gaf_base_ref_free_db() {
+    let gbz_file = utils::get_test_data("micb-kir3dl1.gbz");
+    let gbz_base_file = internal::create_gbz_base_from_files(&gbz_file, None);
+    let gbz_base = internal::open_gbz_base(&gbz_base_file);
+    let mut interface = internal::create_graph_interface(&gbz_base);
+
+    let db_file = internal::create_gaf_base_with_params(
+        "micb-kir3dl1_HG003.gaf", "micb-kir3dl1_HG003.gbwt",
+        GraphReference::Db(&mut interface), &GAFBaseParams::default()
+    );
+    let db = internal::open_gaf_base(&db_file);
+    check_gaf_base(&db, UNIDIRECTIONAL_NODES, ALIGNMENTS, BLOCKS, false);
+    check_gaf_base_tags(&db, 1);
+
+    drop(db);
+    let _ = std::fs::remove_file(&db_file);
+    drop(interface);
+    drop(gbz_base);
+    let _ = std::fs::remove_file(&gbz_base_file);
+}
+
 //-----------------------------------------------------------------------------
 

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -551,6 +551,23 @@ fn gaf_base_no_quality() {
 }
 
 #[test]
+fn gaf_base_no_optional() {
+    let mut params = GAFBaseParams::default();
+    params.store_optional_fields = false;
+
+    let db_file = internal::create_gaf_base_with_params(
+        "micb-kir3dl1_HG003.gaf", "micb-kir3dl1_HG003.gbwt",
+        GraphReference::None, &params
+    );
+    let db = internal::open_gaf_base(&db_file);
+    check_gaf_base(&db, UNIDIRECTIONAL_NODES, ALIGNMENTS, BLOCKS, false);
+    check_gaf_base_tags(&db, 1);
+
+    drop(db);
+    let _ = std::fs::remove_file(&db_file);
+}
+
+#[test]
 fn gaf_base_ref_free() {
     let gbz_file = utils::get_test_data("micb-kir3dl1.gbz");
     let graph: GBZ = serialize::load_from(&gbz_file).unwrap();

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -48,11 +48,14 @@ pub(crate) fn create_graph_interface(database: &GBZBase) -> GraphInterface<'_> {
 // GAF-base utilities.
 
 pub(crate) fn create_gaf_base(gaf_part: &'static str, gbwt_part: &'static str) -> PathBuf {
+    create_gaf_base_with_params(gaf_part, gbwt_part, GraphReference::None, &GAFBaseParams::default())
+}
+
+pub(crate) fn create_gaf_base_with_params(gaf_part: &'static str, gbwt_part: &'static str, graph: GraphReference<'_, '_>, params: &GAFBaseParams) -> PathBuf {
     let gaf_file = utils::get_test_data(gaf_part);
     let gbwt_file = utils::get_test_data(gbwt_part);
     let db_file = serialize::temp_file_name("gaf-base");
-    let params = GAFBaseParams::default();
-    let result = GAFBase::create_from_files(&gaf_file, &gbwt_file, &db_file, GraphReference::None, &params);
+    let result = GAFBase::create_from_files(&gaf_file, &gbwt_file, &db_file, graph, params);
     assert!(result.is_ok(), "Failed to create GAF-base database: {}", result.unwrap_err());
     db_file
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,5 +1,5 @@
 use crate::{GBZBase, GraphInterface, formats};
-use crate::{GAFBase, GAFBaseParams};
+use crate::{GAFBase, GAFBaseParams, GraphReference};
 use crate::{Alignment, PathIndex, Chains};
 use crate::utils;
 
@@ -52,7 +52,7 @@ pub(crate) fn create_gaf_base(gaf_part: &'static str, gbwt_part: &'static str) -
     let gbwt_file = utils::get_test_data(gbwt_part);
     let db_file = serialize::temp_file_name("gaf-base");
     let params = GAFBaseParams::default();
-    let result = GAFBase::create_from_files(&gaf_file, &gbwt_file, &db_file, &params);
+    let result = GAFBase::create_from_files(&gaf_file, &gbwt_file, &db_file, GraphReference::None, &params);
     assert!(result.is_ok(), "Failed to create GAF-base database: {}", result.unwrap_err());
     db_file
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@
 //! It is mostly compatible with the GAF format.
 //! Target paths are stored as a GBWT index in table `Nodes`, which is similar to the table in GBZ-base.
 //!
+//! The default GAF-base is reference-based and requires the corresponding GBZ graph or GBZ-base for decoding the alignments.
+//! It is also possible to build a reference-free GAF-base that stores the node sequences in table `Nodes`.
+//!
 //! Alignment metadata is stored in table `Alignments`.
 //! Each row in the table corresponds to a block of alignments, which are assumed to be close in the graph.
 //! The metadata is stored space-efficiently using column-based compression.

--- a/src/read_set.rs
+++ b/src/read_set.rs
@@ -286,7 +286,7 @@ impl ReadSet {
         // we have encountered to avoid duplicating reads that overlap multiple clusters.
         let mut row_ids: HashSet<usize> = HashSet::new();
         let mut get_reads = database.connection.prepare(
-            "SELECT rowid, min_handle, max_handle, alignments, read_length, gbwt_starts, names, quality_strings, difference_strings, flags, numbers
+            "SELECT id, min_handle, max_handle, alignments, read_length, gbwt_starts, names, quality_strings, difference_strings, flags, numbers
             FROM Alignments
             WHERE min_handle <= ?1 AND max_handle >= ?2"
         ).map_err(|x| x.to_string())?;
@@ -380,7 +380,7 @@ impl ReadSet {
         let mut get_reads = database.connection.prepare(
             "SELECT min_handle, max_handle, alignments, read_length, gbwt_starts, names, quality_strings, difference_strings, flags, numbers
             FROM Alignments
-            WHERE rowid >= ?1 AND rowid < ?2"
+            WHERE id >= ?1 AND id < ?2"
         ).map_err(|x| x.to_string())?;
         let mut rows = get_reads.query((row_range.start, row_range.end)).map_err(|x| x.to_string())?;
         while let Some(row) = rows.next().map_err(|x| x.to_string())? {

--- a/src/read_set.rs
+++ b/src/read_set.rs
@@ -255,7 +255,8 @@ impl ReadSet {
                     let edge_bytes: Vec<u8> = row.get(0)?;
                     let (edges, _) = Record::decompress_edges(&edge_bytes).unwrap();
                     let bwt: Vec<u8> = row.get(1)?;
-                    let sequence: Vec<u8> = row.get(2)?;
+                    let encoded_sequence: Vec<u8> = row.get(2)?;
+                    let sequence = utils::decode_sequence(&encoded_sequence);
                     Ok((edges, bwt, sequence))
                 }
             ).optional().map_err(|x| x.to_string())?;
@@ -364,7 +365,8 @@ impl ReadSet {
                     let edge_bytes: Vec<u8> = row.get(0)?;
                     let (edges, _) = Record::decompress_edges(&edge_bytes).unwrap();
                     let bwt: Vec<u8> = row.get(1)?;
-                    let sequence: Vec<u8> = row.get(2)?;
+                    let encoded_sequence: Vec<u8> = row.get(2)?;
+                    let sequence = utils::decode_sequence(&encoded_sequence);
                     Ok((edges, bwt, sequence))
                 }
             ).optional().map_err(|x| x.to_string())?;

--- a/src/read_set.rs
+++ b/src/read_set.rs
@@ -141,7 +141,7 @@ impl ReadSet {
         block.decode()
     }
 
-    // Replaces the GBWT starting position of the alignment with the path.
+    // Replaces the GBWT starting position of the alignment with the path and sets the true target path length.
     // Requires that the path overlaps with / is fully contained in the subgraph.
     // If the path is valid, inserts all missing node records into the read set.
     fn set_target_path(
@@ -156,6 +156,7 @@ impl ReadSet {
 
         let mut path = Vec::new();
         let mut overlap = false;
+        let mut target_path_len = 0;
         while let Some(p) = pos {
             if subgraph.has_handle(p.node) {
                 overlap = true;
@@ -174,17 +175,19 @@ impl ReadSet {
             // Navigate to the next position.
             path.push(p.node);
             let record = record.unwrap();
+            target_path_len += record.sequence_len();
             pos = record.to_gbwt_record().lf(p.offset);
         }
 
         // Set the target path in the alignment.
         if overlap {
             alignment.set_target_path(path);
+            alignment.set_target_path_len(target_path_len);
         }
         Ok(())
     }
 
-    // Replaces the GBWT starting position of the alignment with the path.
+    // Replaces the GBWT starting position of the alignment with the path and sets the true target path length.
     // Inserts all missing node records into the read set.
     fn set_target_path_simple(
         &mut self, alignment: &mut Alignment,
@@ -196,6 +199,7 @@ impl ReadSet {
         };
 
         let mut path = Vec::new();
+        let mut target_path_len = 0;
         while let Some(p) = pos {
             // Now get the record for the node.
             let mut record = self.nodes.get(&p.node);
@@ -208,11 +212,13 @@ impl ReadSet {
             // Navigate to the next position.
             path.push(p.node);
             let record = record.unwrap();
+            target_path_len += record.sequence_len();
             pos = record.to_gbwt_record().lf(p.offset);
         }
 
         // Set the target path in the alignment.
         alignment.set_target_path(path);
+        alignment.set_target_path_len(target_path_len);
         Ok(())
     }
 

--- a/src/read_set.rs
+++ b/src/read_set.rs
@@ -374,11 +374,15 @@ impl ReadSet {
                 return Err(format!("Could not find the record for handle {} in GAF-base", handle));
             }
             let (edges, bwt, mut sequence) = gaf_result.unwrap();
-            if sequence.is_empty() && let Some(graph) = graph {
-                let seq = graph.sequence(support::node_id(handle)).ok_or(
-                    format!("Could not find the sequence for handle {} in GBZ", handle)
-                )?;
-                sequence = seq.to_vec();
+            if sequence.is_empty() {
+                if let Some(graph) = graph {
+                    let seq = graph.sequence(support::node_id(handle)).ok_or(
+                        format!("Could not find the sequence for handle {} in GBZ", handle)
+                    )?;
+                    sequence = seq.to_vec();
+                } else {
+                    return Err(String::from("No reference provided for a reference-based GAF-base"));
+                }
             }
             if support::node_orientation(handle) == Orientation::Reverse {
                 sequence = support::reverse_complement(&sequence);

--- a/src/read_set.rs
+++ b/src/read_set.rs
@@ -133,11 +133,13 @@ impl ReadSet {
         let difference_strings: Vec<u8> = row.get(from_idx + 7).map_err(|x| x.to_string())?;
         let flags: Vec<u8> = row.get(from_idx + 8).map_err(|x| x.to_string())?;
         let numbers: Vec<u8> = row.get(from_idx + 9).map_err(|x| x.to_string())?;
+        let optional: Vec<u8> = row.get(from_idx + 10).map_err(|x| x.to_string())?;
         let block = AlignmentBlock {
             min_handle, max_handle, alignments, read_length,
             gbwt_starts, names,
             quality_strings, difference_strings,
-            flags: Flags::from(flags), numbers
+            flags: Flags::from(flags), numbers,
+            optional,
         };
         block.decode()
     }
@@ -296,7 +298,7 @@ impl ReadSet {
         // we have encountered to avoid duplicating reads that overlap multiple clusters.
         let mut row_ids: HashSet<usize> = HashSet::new();
         let mut get_reads = database.connection.prepare(
-            "SELECT id, min_handle, max_handle, alignments, read_length, gbwt_starts, names, quality_strings, difference_strings, flags, numbers
+            "SELECT id, min_handle, max_handle, alignments, read_length, gbwt_starts, names, quality_strings, difference_strings, flags, numbers, optional
             FROM Alignments
             WHERE min_handle <= ?1 AND max_handle >= ?2"
         ).map_err(|x| x.to_string())?;
@@ -395,7 +397,7 @@ impl ReadSet {
 
         // Get the reads in the given range of row ids.
         let mut get_reads = database.connection.prepare(
-            "SELECT min_handle, max_handle, alignments, read_length, gbwt_starts, names, quality_strings, difference_strings, flags, numbers
+            "SELECT min_handle, max_handle, alignments, read_length, gbwt_starts, names, quality_strings, difference_strings, flags, numbers, optional
             FROM Alignments
             WHERE id >= ?1 AND id < ?2"
         ).map_err(|x| x.to_string())?;

--- a/src/read_set.rs
+++ b/src/read_set.rs
@@ -230,7 +230,7 @@ impl ReadSet {
     ///
     /// # Arguments
     ///
-    /// * `graph`: A GBZ-compatible graph, or no graph if the GAF-base contains sequences.
+    /// * `graph`: A GBZ-compatible graph for querying a reference-based GAF-base, or no graph for a reference-free one.
     /// * `subgraph`: The subgraph used as the query region.
     /// * `database`: A database storing reads aligned to the graph.
     /// * `output`: Which reads to include in the read set.
@@ -264,7 +264,7 @@ impl ReadSet {
             }
             let (edges, bwt, mut sequence) = gaf_result.unwrap();
 
-            // If the GAF-base does not contain node sequences, try to get the sequence from the
+            // If we have a reference-based database, try to get the sequence from the
             // subgraph or the original graph.
             if sequence.is_empty() {
                 let seq = subgraph.sequence_for_handle(handle);
@@ -342,7 +342,7 @@ impl ReadSet {
     ///
     /// * `database`: A database storing reads aligned to the graph.
     /// * `row_range`: The range of row ids to extract.
-    /// * `graph`: A GBZ graph if the database does not contain node sequences.
+    /// * `graph`: A GBZ graph if the database is reference-based, or [`None`] for a reference-free one.
     ///
     /// # Errors
     ///

--- a/src/read_set/tests.rs
+++ b/src/read_set/tests.rs
@@ -204,7 +204,7 @@ fn read_set_from_rows() {
         let mut rowid = 1; // SQLite row ids start from 1.
         while found_alns < gaf_base.alignments() {
             let range = rowid..(rowid + chunk_size);
-            let read_set = ReadSet::from_rows(&gaf_base, range.clone(), &graph);
+            let read_set = ReadSet::from_rows(&gaf_base, range.clone(), Some(&graph));
             assert!(read_set.is_ok(), "Failed to extract reads from rows {}..{}: {}", range.start, range.end, read_set.unwrap_err());
             let read_set = read_set.unwrap();
 

--- a/src/read_set/tests.rs
+++ b/src/read_set/tests.rs
@@ -253,7 +253,7 @@ fn read_set_from_rows() {
     let gaf_base = internal::open_gaf_base(&gaf_base_file);
 
     // Parse the reads as a source of truth.
-    let mut all_reads = internal::load_gaf_base_reads(false);
+    let all_reads = internal::load_gaf_base_reads(false);
 
     let chunk_sizes = vec![1, 2, 5];
     for chunk_size in chunk_sizes {
@@ -269,8 +269,7 @@ fn read_set_from_rows() {
             assert_eq!(read_set.len(), read_set.unclipped(), "Extracted clipped alignments from rows {}..{}", range.start, range.end);
             assert!(found_alns + read_set.len() <= all_reads.len(), "Extracted too many alignments from rows {}..{}", range.start, range.end);
             for (i, aln) in read_set.iter().enumerate() {
-                let truth = &mut all_reads[found_alns + i];
-                truth.optional.clear(); // We do not store unknown optional fields for the moment.
+                let truth = &all_reads[found_alns + i];
                 assert_eq!(aln, truth, "Wrong read {} from rows {}..{}", i, range.start, range.end);
             }
 

--- a/src/read_set/tests.rs
+++ b/src/read_set/tests.rs
@@ -167,6 +167,13 @@ fn read_set_gbz_no_quality() {
 }
 
 #[test]
+fn read_set_gbz_no_optional() {
+    let mut params = GAFBaseParams::default();
+    params.store_optional_fields = false;
+    test_read_set_gbz("micb-kir3dl1_HG003.gbwt", &params);
+}
+
+#[test]
 fn read_set_gbz_ref_free() {
     let mut params = GAFBaseParams::default();
     params.reference_free = true;
@@ -233,6 +240,13 @@ fn read_set_db_bidirectional() {
 fn read_set_db_no_quality() {
     let mut params = GAFBaseParams::default();
     params.store_quality_strings = false;
+    test_read_set_db("micb-kir3dl1_HG003.gbwt", &params);
+}
+
+#[test]
+fn read_set_db_no_optional() {
+    let mut params = GAFBaseParams::default();
+    params.store_optional_fields = false;
     test_read_set_db("micb-kir3dl1_HG003.gbwt", &params);
 }
 

--- a/src/read_set/tests.rs
+++ b/src/read_set/tests.rs
@@ -110,7 +110,7 @@ fn read_set_default() {
 fn test_read_set_gbz(gbwt_part: &'static str, params: &GAFBaseParams) {
     // Load GBZ.
     let graph = internal::load_gaf_base_gbz();
-    let graph_ref = if params.store_sequences {
+    let graph_ref = if params.reference_free {
         GraphReference::Gbz(&graph)
     } else {
         GraphReference::None
@@ -131,7 +131,7 @@ fn test_read_set_gbz(gbwt_part: &'static str, params: &GAFBaseParams) {
 
         for output in [AlignmentOutput::Overlapping, AlignmentOutput::Clipped, AlignmentOutput::Contained] {
             // The graph reference we use for querying is the opposite of the one used for building the database.
-            let graph_ref = if params.store_sequences {
+            let graph_ref = if params.reference_free {
                 GraphReference::None
             } else {
                 GraphReference::Gbz(&graph)
@@ -169,7 +169,7 @@ fn read_set_gbz_no_quality() {
 #[test]
 fn read_set_gbz_ref_free() {
     let mut params = GAFBaseParams::default();
-    params.store_sequences = true;
+    params.reference_free = true;
     test_read_set_gbz("micb-kir3dl1_HG003.gbwt", &params);
 }
 
@@ -177,7 +177,7 @@ fn test_read_set_db(gbwt_part: &'static str, params: &GAFBaseParams) {
     // Open GBZ-base.
     let (gbz_base, gbz_base_file) = internal::create_gaf_base_db();
     let mut graph = internal::create_graph_interface(&gbz_base);
-    let graph_ref = if params.store_sequences {
+    let graph_ref = if params.reference_free {
         GraphReference::Db(&mut graph)
     } else {
         GraphReference::None
@@ -198,7 +198,7 @@ fn test_read_set_db(gbwt_part: &'static str, params: &GAFBaseParams) {
 
         for output in [AlignmentOutput::Overlapping, AlignmentOutput::Clipped, AlignmentOutput::Contained] {
             // The graph reference we use for querying is the opposite of the one used for building the database.
-            let graph_ref = if params.store_sequences {
+            let graph_ref = if params.reference_free {
                 GraphReference::None
             } else {
                 GraphReference::Db(&mut graph)
@@ -239,7 +239,7 @@ fn read_set_db_no_quality() {
 #[test]
 fn read_set_db_ref_free() {
     let mut params = GAFBaseParams::default();
-    params.store_sequences = true;
+    params.reference_free = true;
     test_read_set_db("micb-kir3dl1_HG003.gbwt", &params);
 }
 

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -690,6 +690,7 @@ impl Subgraph {
     ///
     /// # Errors
     ///
+    /// Returns an error if the graph reference is [`GraphReference::None`].
     /// Passes through errors from accessing the graph.
     ///
     /// # Examples
@@ -732,6 +733,9 @@ impl Subgraph {
                 }
                 GraphReference::Db(graph) => {
                     inserted += self.between_nodes(GraphReference::Db(graph), start, end, None)?;
+                },
+                GraphReference::None => {
+                    return Err(String::from("No graph reference provided"));
                 }
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -61,6 +61,7 @@ pub fn file_exists<P: AsRef<Path>>(filename: P) -> bool {
     fs::metadata(filename).is_ok()
 }
 
+// FIXME: Take a buffered reader instead and put the magic numbers back into the buffer.
 /// Returns `true` if the file appears to be gzip-compressed.
 pub fn is_gzipped<P: AsRef<Path>>(filename: P) -> bool {
     let file = File::open(filename).ok();
@@ -73,6 +74,7 @@ pub fn is_gzipped<P: AsRef<Path>>(filename: P) -> bool {
     len == Some(2) && magic == [0x1F, 0x8B]
 }
 
+// FIXME: Use - to indicate stdin.
 /// Returns a buffered reader for the file, which may be gzip-compressed.
 pub fn open_file<P: AsRef<Path>>(filename: P) -> Result<Box<dyn BufRead>, String> {
     let file = File::open(&filename).map_err(|x| x.to_string())?;


### PR DESCRIPTION
Many small improvements to GAF-base:

* More space-efficient representation of numerical values.
* Option to make the GAF-base reference-free by storing sequences in table `Nodes`.
* Option to leave quality strings out.
* Unknown optional fields are now stored in the database, but they can be left out.