### PR TITLE
GBWT construction for GAF-base

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ readme = "README.md"
 repository = "https://github.com/jltsiren/gbz-base"
 
 [dependencies]
-gbz = { version = "0.5.1" }
+gbz = { version = "0.6" }
 simple-sds = { version = "0.4" }
-pggname = { version = "0.2" }
+pggname = { git = "https://github.com/jltsiren/pggname.git" }
+#pggname = { version = "0.2" }
 # Use fallible_uint for getting usize values from query results.
 rusqlite = { version = "0.38", features = ["bundled", "fallible_uint"] }
 getopts = { version = "0.2" }

--- a/README.md
+++ b/README.md
@@ -56,32 +56,32 @@ gbz2db --chains graph.chains graph.gbz
 ### Sorting the reads
 
 Before building a GAF-base, you must first sort the alignments and build a GBWT index of the target paths.
-This can be done using [vg](https://github.com/vgteam/vg):
+This can be done using the bundled `gafsort` tool (or with `vg gamsort`):
 
 ```sh
-vg gamsort --progress --threads 6 \
-    --gbwt-output sorted.gbwt \
-    --gaf-input reads.gaf.gz | bgzip --threads 4 > sorted.gaf.gz
+gafsort --progress --threads 6 reads.gaf.gz | bgzip --threads 4 > sorted.gaf.gz
 ```
 
-`sorted.gaf.gz` now contains the sorted reads and `sorted.gbwt` the target paths in the same order.
-Six worker threads are generally enough when reading a gzip-compressed GAF file.
-Four compression threads should be sufficient when building a GBWT index.
+`sorted.gaf.gz` now contains the sorted reads.
+Six worker threads and four compression threads should be sufficient due to sequential bottlenecks.
 
 The default chunk size (1 million lines) is appropriate for short reads.
 When sorting long reads, it can be changed with `--chunk-size N` (e.g. `--chunk-size 10000` for 20 kpb reads).
 
 ### Building the GAF-base
 
-GAF-base construction takes both the sorted reads and the GBWT index:
+GAF-base construction takes the sorted reads:
 
 ```sh
-gaf2db --gbwt sorted.gbwt sorted.gaf.gz
+gaf2db sorted.gaf.gz
 ```
 
 The reads can be uncompressed or compressed with gzip.
 Default output file is `<input>.db`.
 Options `--output` and `--overwrite` are the same as in GBZ-base construction.
+
+A prebuilt GBWT index (e.g. from `vg gamsort`) can be provided with `--gbwt FILE`.
+This will lower the memory requirements for GAF-base construction, but it will not make the construction faster.
 
 The default block size (1000 alignments) is appropriate for short reads.
 When building a database of long read alignments, it can be changed with `--block-size N` (e.g. `--block-size 10` for 20 kbp reads).
@@ -89,7 +89,7 @@ When building a database of long read alignments, it can be changed with `--bloc
 The default GAF-base is reference-based, like the GAF format itself.
 The alignments can only be decoded by using the corresponding GBZ graph or GBZ-base.
 
-A reference-free GAF-base can be built by providing a reference graph during construction with option `--ref-free graph`.
+A reference-free GAF-base can be built by providing a reference graph during construction with option `--ref-free FILE`.
 The graph file should be a GBZ graph.
 A GBZ-base can also be used, but the construction will be much slower.
 Reference-free GAF-bases can be used without a reference graph.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -32,8 +32,9 @@ This is the initial release of GBZ-base and GAF-base.
 
 ## Release process
 
-* Run `cargo clippy`.
+* Run `cargo clippy --features=binaries`.
 * Run tests with `cargo test`.
+* Build documentation with `cargo doc`.
 * Update database versions to non-dev versions in `db.rs`.
 * Update version in `Cargo.toml`.
 * Update `RELEASES.md`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,10 @@
 
 ## Current version
 
-* GAF sorting with `gaf_sort()` and the `gafsort` tool.
+* Database versions: GBZ-base v0.4.0, GAF-base version 3
+* GBZ-base and GAF-base construction without vg:
+  * GAF sorting with `gaf_sort()` and the `gafsort` tool.
+  * GBWT construction in a background thread when building GAF-base.
 * Bug fixes:
   * Exact alignments in a block with varying query lengths are now encoded correctly. GAF-bases must be rebuilt.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,8 @@
 ## Current version
 
 * GAF sorting with `gaf_sort()` and the `gafsort` tool.
+* Bug fixes:
+  * Exact alignments in a block with varying query lengths are now encoded correctly. GAF-bases must be rebuilt.
 
 ## GAF-base 0.3.0 (2026-02-18)
 

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -34,7 +34,7 @@
 
 use crate::{Subgraph, Mapping, Difference};
 use crate::formats::{self, TypedField};
-use crate::utils;
+use crate::utils::{self, PathStartSource};
 
 use std::io::{Read, Write};
 use std::ops::Range;
@@ -44,7 +44,7 @@ use std::{cmp, str};
 use zstd::stream::Encoder as ZstdEncoder;
 use zstd::stream::Decoder as ZstdDecoder;
 
-use gbz::{GBWT, Orientation, Pos};
+use gbz::{GBWT, Orientation, Pos, ENDMARKER};
 use gbz::support::{self, ByteCode, ByteCodeIter, RLE, Run, RLEIter};
 
 #[cfg(test)]
@@ -1327,14 +1327,19 @@ impl AsRef<[u8]> for Flags {
 ///
 /// ```
 /// use gbz_base::{Alignment, AlignmentBlock};
+/// use gbz_base::utils::PathStartSource;
 /// use gbz_base::{formats, utils};
 /// use gbz::GBWT;
 /// use gbz::support;
 /// use simple_sds::serialize;
 ///
-/// // We need a GBWT index of the paths for compressing alignments.
+/// // We assume that the target paths are stored separately in a GBWT index.
 /// let gbwt_filename = utils::get_test_data("micb-kir3dl1_HG003.gbwt");
 /// let index: GBWT = serialize::load_from(&gbwt_filename).unwrap();
+///
+/// // We use the GBWT index for determining the starting position for each path.
+/// // But we could also compute it on the fly with `PathStartSource::new()`.
+/// let mut source = PathStartSource::from(&index);
 ///
 /// // Open a GAF file and skip the header.
 /// let gaf_filename = utils::get_test_data("micb-kir3dl1_HG003.gaf");
@@ -1357,7 +1362,7 @@ impl AsRef<[u8]> for Flags {
 ///
 /// // Compress the block.
 /// let mut first_id = 0;
-/// let block = AlignmentBlock::new(&alignments, &index, first_id).unwrap();
+/// let block = AlignmentBlock::new(&alignments, &mut source, first_id).unwrap();
 /// assert_eq!(block.len(), alignments.len());
 /// first_id += alignments.len(); // Next block would start there.
 ///
@@ -1420,15 +1425,22 @@ impl AlignmentBlock {
         read_length
     }
 
-    fn compress_gbwt_starts(alignments: &[Alignment], index: &GBWT, first_id: usize, min_handle: Option<usize>) -> Result<Vec<u8>, String> {
+    fn compress_gbwt_starts(
+        alignments: &[Alignment],
+        source: &mut PathStartSource,
+        first_id: usize, min_handle: Option<usize>
+    ) -> Result<Vec<u8>, String> {
         let base_node = min_handle.unwrap_or(0);
         let mut encoder = ByteCode::new();
-        for i in 0..alignments.len() {
+        for (i, aln) in alignments.iter().enumerate() {
+            let node_id = if let Some(path) = aln.target_path() {
+                path.first().copied().unwrap_or(ENDMARKER)
+            } else {
+                return Err(format!("Line {}: Cannot compute GBWT start for an alignment without an explicit target path", first_id + i));
+            };
+
             // GBWT start as (node - min_handle, offset).
-            let gbwt_sequence_id = if index.is_bidirectional() {
-                support::encode_path(first_id + i, Orientation::Forward)
-            } else { first_id + i };
-            if let Some(start) = index.start(gbwt_sequence_id) {
+            if let Some(start) = source.next(node_id) {
                 encoder.write(start.node - base_node);
                 encoder.write(start.offset);
             } else if !encoder.is_empty() {
@@ -1501,18 +1513,21 @@ impl AlignmentBlock {
     /// # Arguments
     ///
     /// * `alignments`: The alignments to include in the block.
-    /// * `index`: The GBWT index to use for encoding the GBWT starts.
+    /// * `source`: A source for GBWT starting positions of the target paths.
     /// * `first_id`: Path identifier of the first alignment in the block.
     ///
     /// # Errors
     ///
-    /// Returns an error if the block contains a mix of aligned and unaligned reads.
-    /// Returns an error if compression fails.
-    pub fn new(alignments: &[Alignment], index: &GBWT, first_id: usize) -> Result<Self, String> {
+    /// Returns an error, if:
+    ///
+    /// * The block contains a mix of aligned and unaligned reads.
+    /// * The source computes GBWT starts on the fly, but an alignment does not store the target path explicitly.
+    /// * Compression fails.
+    pub fn new(alignments: &[Alignment], source: &mut PathStartSource, first_id: usize) -> Result<Self, String> {
         let min_handle = alignments.iter().map(|aln| aln.min_handle()).min().flatten();
         let max_handle = alignments.iter().map(|aln| aln.max_handle()).max().flatten();
         let read_length = Self::expected_read_length(alignments);
-        let gbwt_starts = Self::compress_gbwt_starts(alignments, index, first_id, min_handle)?;
+        let gbwt_starts = Self::compress_gbwt_starts(alignments, source, first_id, min_handle)?;
         let names = Self::compress_names_pairs(alignments)?;
         let quality_strings = Self::compress_quality_strings(alignments)?;
         let optional = Self::compress_optional_fields(alignments)?;

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -591,11 +591,11 @@ impl Alignment {
     fn encode_numbers_into(&self, encoder: &mut ByteCode, known_length: bool) {
         let full_alignment = self.is_full();
         let exact_alignment = self.is_exact();
-        let known_alignment = self.has_difference_string();
+        let stored_difference_string = self.has_difference_string() & !exact_alignment;
 
         // Query sequence coordinates. We write the aligned length first to simplify the logic.
         let (left_flank, length, right_flank) = Self::normalize_coordinates(self.seq_interval.clone(), self.seq_len);
-        if !(known_length || known_alignment) {
+        if !(known_length || stored_difference_string) {
             encoder.write(length);
         }
         if !full_alignment {
@@ -606,13 +606,13 @@ impl Alignment {
         // Target path coordinates. We again write the aligned length first.
         // We do not store the right flank, because it can be derived from the path itself.
         let (left_flank, length, _) = Self::normalize_coordinates(self.path_interval.clone(), self.path_len);
-        if !(exact_alignment || known_alignment) {
+        if !(exact_alignment || stored_difference_string) {
             encoder.write(length);
         }
         encoder.write(left_flank);
 
         // Alignment statistics.
-        if !(exact_alignment || known_alignment) {
+        if !(exact_alignment || stored_difference_string) {
             encoder.write(self.matches);
             encoder.write(self.edits);
         }
@@ -1676,7 +1676,8 @@ impl AlignmentBlock {
         for (i, aln) in result.iter_mut().enumerate() {
             let full_alignment = self.flags.get(i, Flags::FLAG_FULL_ALIGNMENT);
             let exact_alignment = self.flags.get(i, Flags::FLAG_EXACT_ALIGNMENT);
-            let known_alignment = aln.has_difference_string();
+            // We did not store the difference string for an exact alignment.
+            let stored_difference_string = aln.has_difference_string();
 
             // Derive the numbers from the difference string first.
             // If the difference string is empty, we get zeros and update them later.
@@ -1687,7 +1688,7 @@ impl AlignmentBlock {
             // Query sequence coordinates.
             if let Some(len) = self.read_length {
                 query_len = len;
-            } else if !known_alignment {
+            } else if !stored_difference_string {
                 query_len = decoder.next().ok_or(format!("Missing query sequence aligned length for alignment {}", i))?;
             }
             let (query_left, query_right) = if full_alignment {
@@ -1707,8 +1708,8 @@ impl AlignmentBlock {
             // Target path coordinates.
             if exact_alignment {
                 target_len = query_len;
-            } else if !known_alignment {
-                target_len = decoder.next().ok_or(format!("Missing target path alignedlength for alignment {}", i))?;
+            } else if !stored_difference_string {
+                target_len = decoder.next().ok_or(format!("Missing target path aligned length for alignment {}", i))?;
             }
             let target_left = decoder.next().ok_or(format!("Missing target path left flank for alignment {}", i))?;
             let target_right = 0; // We can determine the length of the right flank later.
@@ -1719,7 +1720,7 @@ impl AlignmentBlock {
             if exact_alignment {
                 aln.matches = query_len;
                 aln.edits = 0;
-            } else if !known_alignment {
+            } else if !stored_difference_string {
                 aln.matches = decoder.next().ok_or(format!("Missing number of matches for alignment {}", i))?;
                 aln.edits = decoder.next().ok_or(format!("Missing number of edits for alignment {}", i))?;
             }

--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -672,7 +672,7 @@ impl Alignment {
                 2 => {
                     let offset = decoder.offset();
                     for _ in 0..run.len {
-                        let _ = decoder.byte().ok_or(String::from("Missing insertion base"))?;
+                        let _ = decoder.byte().ok_or_else(|| String::from("Missing insertion base"))?;
                     }
                     let encoded = &encoded[offset..offset + run.len];
                     let seq = utils::decode_sequence(encoded);
@@ -891,8 +891,8 @@ impl Alignment {
 
         // TODO: enum?
         // Determine how we are extending the alignment.
-        let target_path = self.target_path().ok_or(
-            "Cannot extend a fragment without an explicit target path"
+        let target_path = self.target_path().ok_or_else(||
+            String::from("Cannot extend a fragment without an explicit target path")
         )?;
         let last_node = target_path.last().copied();
         let path_left = self.path_len.saturating_sub(self.path_interval.end);
@@ -1600,10 +1600,10 @@ impl AlignmentBlock {
         let base_node = self.min_handle.unwrap();
         let mut decoder: ByteCodeIter<'_> = ByteCodeIter::new(&self.gbwt_starts[..]);
         for (i, aln) in result.iter_mut().enumerate() {
-            let start = decoder.next().ok_or(
+            let start = decoder.next().ok_or_else(||
                 format!("Missing GBWT start for alignment {}", i)
             )?;
-            let offset = decoder.next().ok_or(
+            let offset = decoder.next().ok_or_else(||
                 format!("Missing GBWT offset for alignment {}", i)
             )?;
             aln.path = TargetPath::StartPosition(Pos::new(start + base_node, offset));
@@ -1623,9 +1623,9 @@ impl AlignmentBlock {
         let buffer = Self::zstd_decompress(&self.names[..])?;
         let mut iter = buffer.split(|&c| c == 0);
         for (i, aln) in result.iter_mut().enumerate() {
-            let name = iter.next().ok_or(format!("Missing name for alignment {}", i))?;
+            let name = iter.next().ok_or_else(|| format!("Missing name for alignment {}", i))?;
             aln.name = String::from_utf8_lossy(name).to_string();
-            let pair_name = iter.next().ok_or(format!("Missing pair name for alignment {}", i))?;
+            let pair_name = iter.next().ok_or_else(|| format!("Missing pair name for alignment {}", i))?;
             if !pair_name.is_empty() {
                 aln.pair = Some(PairedRead {
                     name: String::from_utf8_lossy(pair_name).to_string(),
@@ -1648,7 +1648,7 @@ impl AlignmentBlock {
         let buffer = Self::zstd_decompress(&self.quality_strings[..])?;
         let mut iter = buffer.split(|&c| c == 0);
         for (i, aln) in result.iter_mut().enumerate() {
-            let quality = iter.next().ok_or(format!("Missing quality string for alignment {}", i))?;
+            let quality = iter.next().ok_or_else(|| format!("Missing quality string for alignment {}", i))?;
             aln.base_quality = quality.to_vec();
         }
         // There should be an empty slice at the end, as the buffer is 0-terminated.
@@ -1689,13 +1689,13 @@ impl AlignmentBlock {
             if let Some(len) = self.read_length {
                 query_len = len;
             } else if !stored_difference_string {
-                query_len = decoder.next().ok_or(format!("Missing query sequence aligned length for alignment {}", i))?;
+                query_len = decoder.next().ok_or_else(|| format!("Missing query sequence aligned length for alignment {}", i))?;
             }
             let (query_left, query_right) = if full_alignment {
                 (0, 0)
             } else {
-                let query_left = decoder.next().ok_or(format!("Missing query sequence left flank for alignment {}", i))?;
-                let query_right = decoder.next().ok_or(format!("Missing query sequence right flank for alignment {}", i))?;
+                let query_left = decoder.next().ok_or_else(|| format!("Missing query sequence left flank for alignment {}", i))?;
+                let query_right = decoder.next().ok_or_else(|| format!("Missing query sequence right flank for alignment {}", i))?;
                 (query_left, query_right)
             };
             if self.read_length.is_some() {
@@ -1709,9 +1709,9 @@ impl AlignmentBlock {
             if exact_alignment {
                 target_len = query_len;
             } else if !stored_difference_string {
-                target_len = decoder.next().ok_or(format!("Missing target path aligned length for alignment {}", i))?;
+                target_len = decoder.next().ok_or_else(|| format!("Missing target path aligned length for alignment {}", i))?;
             }
-            let target_left = decoder.next().ok_or(format!("Missing target path left flank for alignment {}", i))?;
+            let target_left = decoder.next().ok_or_else(|| format!("Missing target path left flank for alignment {}", i))?;
             let target_right = 0; // We can determine the length of the right flank later.
             aln.path_interval = target_left..(target_left + target_len);
             aln.path_len = target_len + target_left + target_right;
@@ -1721,14 +1721,14 @@ impl AlignmentBlock {
                 aln.matches = query_len;
                 aln.edits = 0;
             } else if !stored_difference_string {
-                aln.matches = decoder.next().ok_or(format!("Missing number of matches for alignment {}", i))?;
-                aln.edits = decoder.next().ok_or(format!("Missing number of edits for alignment {}", i))?;
+                aln.matches = decoder.next().ok_or_else(|| format!("Missing number of matches for alignment {}", i))?;
+                aln.edits = decoder.next().ok_or_else(|| format!("Missing number of edits for alignment {}", i))?;
             }
             if self.flags.get(i, Flags::FLAG_HAS_MAPQ) {
-                aln.mapq = Some(decoder.next().ok_or(format!("Missing mapping quality for alignment {}", i))?);
+                aln.mapq = Some(decoder.next().ok_or_else(|| format!("Missing mapping quality for alignment {}", i))?);
             }
             if self.flags.get(i, Flags::FLAG_HAS_SCORE) {
-                aln.score = Some(Alignment::decode_signed(&mut decoder).ok_or(
+                aln.score = Some(Alignment::decode_signed(&mut decoder).ok_or_else(||
                     format!("Missing alignment score for alignment {}", i)
                 )?);
             }
@@ -1746,7 +1746,7 @@ impl AlignmentBlock {
         let buffer = Self::zstd_decompress(&self.optional[..])?;
         let mut iter = buffer.split(|&c| c == 0);
         for (i, aln) in result.iter_mut().enumerate() {
-            let optional = iter.next().ok_or(format!("Missing optional fields for alignment {}", i))?;
+            let optional = iter.next().ok_or_else(|| format!("Missing optional fields for alignment {}", i))?;
             let fields = optional.split(|&c| c == b'\t');
             for field in fields {
                 let parsed = TypedField::parse(field)?;

--- a/src/alignment/mapping.rs
+++ b/src/alignment/mapping.rs
@@ -246,7 +246,7 @@ impl Difference {
                 b'+' => Self::insertion(value),
                 b'-' => Self::deletion(value),
                 _ => return Err(format!("Invalid difference string operation: {}", difference_string[start] as char)),
-            }.ok_or(format!("Invalid difference string field: {}", String::from_utf8_lossy(&difference_string[start..end])))?;
+            }.ok_or_else(|| format!("Invalid difference string field: {}", String::from_utf8_lossy(&difference_string[start..end])))?;
             result.push(op);
             start = end;
         }

--- a/src/alignment/tests.rs
+++ b/src/alignment/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::{Subgraph, SubgraphQuery, GraphReference};
 use crate::utils::{self, PathStartSource};
 
-use gbz::GBZ;
+use gbz::{GBWTBuilder, GBZ};
 use simple_sds::serialize;
 
 use rand::Rng;
@@ -428,6 +428,50 @@ fn alignment_real_gzipped() {
 #[test]
 fn alignment_real_compute_path_starts() {
     integration_test("micb-kir3dl1_HG003.gaf", "micb-kir3dl1_HG003.gbwt", 456, true);
+}
+
+#[test]
+fn alignment_block_special_cases() {
+    let sequence_len = Arc::new(|handle| Some(handle));
+    let alignments = vec![
+        create_alignment(
+            "perfect-100",
+            100, 0,
+            vec![42, 63], 2,
+            vec![Difference::Match(100)],
+            Some(sequence_len.clone()),
+        ),
+        create_alignment(
+            "imperfect-100",
+            100, 0,
+            vec![44, 68], 7,
+            vec![Difference::Match(66), Difference::Mismatch(b'A'), Difference::Match(33)],
+            Some(sequence_len.clone()),
+        ),
+        // There used to be a bug with exact alignments in blocks where the alignment length varied.
+        create_alignment(
+            "perfect-101",
+            101, 0,
+            vec![52, 63], 10,
+            vec![Difference::Match(101)],
+            Some(sequence_len.clone()),
+        ),
+        create_alignment(
+            "with-gap-100",
+            100, 0,
+            vec![46, 70], 5,
+            vec![Difference::Match(50), Difference::Deletion(5), Difference::Match(50)],
+            Some(sequence_len.clone()),
+        ),
+    ];
+
+    let mut builder = GBWTBuilder::new(false, false, 1000);
+    for aln in alignments.iter() {
+        let _ = builder.insert(aln.target_path().unwrap(), None);
+    }
+    let index = builder.build().unwrap();
+    let mut source = PathStartSource::from(&index);
+    check_encode_decode(&alignments, &index, &mut source, 0);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/alignment/tests.rs
+++ b/src/alignment/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::{Subgraph, SubgraphQuery, GraphReference};
-use crate::utils;
+use crate::utils::{self, PathStartSource};
 
 use gbz::GBZ;
 use simple_sds::serialize;
@@ -352,9 +352,9 @@ fn block_end(alignments: &[Alignment], start: usize, block_size: usize) -> usize
     end
 }
 
-fn check_encode_decode(block: &[Alignment], index: &GBWT, first_id: usize) {
+fn check_encode_decode(block: &[Alignment], index: &GBWT, source: &mut PathStartSource, first_id: usize) {
     let range = first_id..(first_id + block.len());
-    let encoded = AlignmentBlock::new(block, index, first_id);
+    let encoded = AlignmentBlock::new(block, source, first_id);
     if let Err(message) = encoded {
         panic!("Failed to encode the alignment block {}..{}: {}", range.start, range.end, message);
     }
@@ -381,7 +381,7 @@ fn check_encode_decode(block: &[Alignment], index: &GBWT, first_id: usize) {
 // Tests for `Alignment`: encode/decode integration.
 // This is the haplotype sampling test case from vg.
 
-fn integration_test(gaf_file: &'static str, gbwt_file: &'static str, block_size: usize) {
+fn integration_test(gaf_file: &'static str, gbwt_file: &'static str, block_size: usize, compute_path_starts: bool) {
     // Parse the alignments.
     let gaf_file = utils::get_test_data(gaf_file);
     let alignments = parse_alignments(&gaf_file, false);
@@ -391,29 +391,43 @@ fn integration_test(gaf_file: &'static str, gbwt_file: &'static str, block_size:
     let gbwt_file = utils::get_test_data(gbwt_file);
     let index: GBWT = serialize::load_from(&gbwt_file).unwrap();
 
+    // We either use the provided GBWT index for computing GBWT starts,
+    // or we compute them on the fly, assuming a unidirectional index.
+    let mut source = if compute_path_starts {
+        assert!(!index.is_bidirectional(), "Cannot compute GBWT starts on the fly for a bidirectional index");
+        PathStartSource::new()
+    } else {
+        PathStartSource::from(&index)
+    };
+
     // Encode and decode the alignments.
     let mut start = 0;
     while start < alignments.len() {
         let end = block_end(&alignments, start, block_size);
         let block = &alignments[start..end];
-        check_encode_decode(block, &index, start);
+        check_encode_decode(block, &index, &mut source, start);
         start = end;
     }
 }
 
 #[test]
 fn alignment_real() {
-    integration_test("micb-kir3dl1_HG003.gaf", "micb-kir3dl1_HG003.gbwt", 1234);
+    integration_test("micb-kir3dl1_HG003.gaf", "micb-kir3dl1_HG003.gbwt", 1234, false);
 }
 
 #[test]
 fn alignment_bidirectional() {
-    integration_test("micb-kir3dl1_HG003.gaf", "bidirectional.gbwt", 1001);
+    integration_test("micb-kir3dl1_HG003.gaf", "bidirectional.gbwt", 1001, false);
 }
 
 #[test]
 fn alignment_real_gzipped() {
-    integration_test("micb-kir3dl1_HG003.gaf.gz", "micb-kir3dl1_HG003.gbwt", 789);
+    integration_test("micb-kir3dl1_HG003.gaf.gz", "micb-kir3dl1_HG003.gbwt", 789, false);
+}
+
+#[test]
+fn alignment_real_compute_path_starts() {
+    integration_test("micb-kir3dl1_HG003.gaf", "micb-kir3dl1_HG003.gbwt", 456, true);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/bin/db2gaf.rs
+++ b/src/bin/db2gaf.rs
@@ -73,7 +73,7 @@ fn write_gaf(database: &GAFBase, alignments: &GraphName, graph: Option<&GBZ>, co
                 .map_err(|e| e.to_string());
         }
         while status.is_ok() {
-            let read_set: ReadSet = from_decoder.recv().unwrap_or(ReadSet::default());
+            let read_set: ReadSet = from_decoder.recv().unwrap_or_else(|_| ReadSet::default());
             if read_set.is_empty() {
                 break;
             }

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -121,11 +121,7 @@ impl Config {
             eprint!("{}", opts.usage(&header));
             process::exit(0);
         }
-        let gbwt_file = if let Some(s) = matches.opt_str("g") {
-            Some(PathBuf::from(s))
-        } else {
-            None
-        };
+        let gbwt_file = matches.opt_str("g").map(PathBuf::from);
         let graph_file = if let Some(s) = matches.opt_str("r") {
             params.reference_free = true;
             Some(PathBuf::from(s))

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), String> {
                 eprintln!("Loading GBZ graph {}", graph_file.display());
                 let graph: GBZ = serialize::load_from(graph_file).map_err(|x| x.to_string())?;
                 GAFBase::create_from_files(
-                    &config.gaf_file, Some(&config.gbwt_file), &config.db_file,
+                    &config.gaf_file, config.gbwt_file.as_deref(), &config.db_file,
                     GraphReference::Gbz(&graph), &config.params
                 )?;
             },
@@ -51,7 +51,7 @@ fn main() -> Result<(), String> {
                 let database = GBZBase::open(graph_file)?;
                 let mut graph = GraphInterface::new(&database)?;
                 GAFBase::create_from_files(
-                    &config.gaf_file, Some(&config.gbwt_file), &config.db_file,
+                    &config.gaf_file, config.gbwt_file.as_deref(), &config.db_file,
                     GraphReference::Db(&mut graph), &config.params
                 )?;
             },
@@ -60,7 +60,7 @@ fn main() -> Result<(), String> {
             }
         };
     } else {
-        GAFBase::create_from_files(&config.gaf_file, Some(&config.gbwt_file), &config.db_file, GraphReference::None, &config.params)?;
+        GAFBase::create_from_files(&config.gaf_file, config.gbwt_file.as_deref(), &config.db_file, GraphReference::None, &config.params)?;
     }
 
     // Statistics.
@@ -83,7 +83,7 @@ fn main() -> Result<(), String> {
 
 struct Config {
     pub gaf_file: PathBuf,
-    pub gbwt_file: PathBuf,
+    pub gbwt_file: Option<PathBuf>,
     pub graph_file: Option<PathBuf>,
     pub db_file: PathBuf,
     pub overwrite: bool,
@@ -100,7 +100,7 @@ impl Config {
 
         let mut opts = Options::new();
         opts.optflag("h", "help", "print this help");
-        opts.optopt("g", "gbwt", "GBWT file name (required)", "FILE");
+        opts.optopt("g", "gbwt", "GBWT file name", "FILE");
         opts.optopt("r", "ref-free", "build a reference-free GAF-base using this graph", "FILE");
         let block_desc = format!("number of alignments per block (default: {})", params.block_size);
         opts.optopt("b", "block-size", &block_desc, "INT");
@@ -122,10 +122,9 @@ impl Config {
             process::exit(0);
         }
         let gbwt_file = if let Some(s) = matches.opt_str("g") {
-            PathBuf::from(s)
+            Some(PathBuf::from(s))
         } else {
-            eprint!("{}", opts.usage(&header));
-            process::exit(1);
+            None
         };
         let graph_file = if let Some(s) = matches.opt_str("r") {
             params.reference_free = true;

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -69,7 +69,7 @@ fn main() -> Result<(), String> {
         "The database contains {} nodes and {} alignments in {} blocks",
         database.nodes(), database.alignments(), database.blocks()
     );
-    let size = database.file_size().unwrap_or(String::from("unknown"));
+    let size = database.file_size().unwrap_or_else(|| String::from("unknown"));
     eprintln!("Final database size: {}", size);
 
     let end_time = Instant::now();

--- a/src/bin/gaf2db.rs
+++ b/src/bin/gaf2db.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), String> {
                 eprintln!("Loading GBZ graph {}", graph_file.display());
                 let graph: GBZ = serialize::load_from(graph_file).map_err(|x| x.to_string())?;
                 GAFBase::create_from_files(
-                    &config.gaf_file, &config.gbwt_file, &config.db_file,
+                    &config.gaf_file, Some(&config.gbwt_file), &config.db_file,
                     GraphReference::Gbz(&graph), &config.params
                 )?;
             },
@@ -51,7 +51,7 @@ fn main() -> Result<(), String> {
                 let database = GBZBase::open(graph_file)?;
                 let mut graph = GraphInterface::new(&database)?;
                 GAFBase::create_from_files(
-                    &config.gaf_file, &config.gbwt_file, &config.db_file,
+                    &config.gaf_file, Some(&config.gbwt_file), &config.db_file,
                     GraphReference::Db(&mut graph), &config.params
                 )?;
             },
@@ -60,7 +60,7 @@ fn main() -> Result<(), String> {
             }
         };
     } else {
-        GAFBase::create_from_files(&config.gaf_file, &config.gbwt_file, &config.db_file, GraphReference::None, &config.params)?;
+        GAFBase::create_from_files(&config.gaf_file, Some(&config.gbwt_file), &config.db_file, GraphReference::None, &config.params)?;
     }
 
     // Statistics.

--- a/src/bin/gafsort.rs
+++ b/src/bin/gafsort.rs
@@ -112,7 +112,7 @@ impl Config {
             PathBuf::from("-") // Use stdout if no output file is specified
         };
 
-        let mut params = SortParameters::default();
+        let mut params = SortParameters::new();
 
         // Parse key type
         params.key_type = if let Some(s) = matches.opt_str("k") {

--- a/src/bin/gbz2db.rs
+++ b/src/bin/gbz2db.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), String> {
     eprintln!("There are {} paths representing {} samples, {} haplotypes, and {} contigs",
         database.paths(), database.samples(), database.haplotypes(), database.contigs()
     );
-    let size = database.file_size().unwrap_or(String::from("unknown"));
+    let size = database.file_size().unwrap_or_else(|| String::from("unknown"));
     eprintln!("Final database size: {}", size);
 
     let end_time = Instant::now();

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -215,9 +215,9 @@ impl Config {
 
     fn parse_interval(s: &str) -> Result<Range<usize>, String> {
         let mut parts = s.split("..");
-        let start = parts.next().ok_or(format!("Invalid interval: {}", s))?;
+        let start = parts.next().ok_or_else(|| format!("Invalid interval: {}", s))?;
         let start = start.parse::<usize>().map_err(|x| format!("Failed to parse interval start: {}", x))?;
-        let end = parts.next().ok_or(format!("Invalid interval: {}", s))?;
+        let end = parts.next().ok_or_else(|| format!("Invalid interval: {}", s))?;
         let end = end.parse::<usize>().map_err(|x| format!("Failed to parse interval end: {}", x))?;
         if parts.next().is_some() {
             return Err(format!("Invalid interval: {}", s));
@@ -243,9 +243,9 @@ impl Config {
 
     fn parse_between(s: &str) -> Result<(usize, usize), String> {
         let mut parts = s.split(':');
-        let start = parts.next().ok_or(format!("Invalid pair of (oriented) nodes: {}", s))?;
+        let start = parts.next().ok_or_else(|| format!("Invalid pair of (oriented) nodes: {}", s))?;
         let start = Self::parse_handle(start)?;
-        let end = parts.next().ok_or(format!("Invalid pair of (oriented) nodes: {}", s))?;
+        let end = parts.next().ok_or_else(|| format!("Invalid pair of (oriented) nodes: {}", s))?;
         let end = Self::parse_handle(end)?;
         if parts.next().is_some() {
             return Err(format!("Invalid pair of (oriented) nodes: {}", s));
@@ -269,8 +269,8 @@ impl Config {
         }
 
         let path_name = if needs_path_name {
-            let sample = matches.opt_str("sample").unwrap_or(String::from(GENERIC_SAMPLE));
-            let contig = matches.opt_str("contig").ok_or(String::from("Contig name must be provided with --contig"))?;
+            let sample = matches.opt_str("sample").unwrap_or_else(|| String::from(GENERIC_SAMPLE));
+            let contig = matches.opt_str("contig").ok_or_else(|| String::from("Contig name must be provided with --contig"))?;
             Some(FullPathName::reference(&sample, &contig))
         } else {
             None

--- a/src/db.rs
+++ b/src/db.rs
@@ -471,7 +471,6 @@ impl GBZBase {
 
 //-----------------------------------------------------------------------------
 
-// FIXME: Tests that build a GBWT instead of loading it.
 /// A database connection to a GAF-base database.
 ///
 /// This structure stores a database connection and some header information.

--- a/src/db.rs
+++ b/src/db.rs
@@ -223,7 +223,7 @@ impl GBZBase {
 
     // Sanity checks for the GBZ graph. We do not want to handle graphs without sufficient metadata.
     fn sanity_checks(graph: &GBZ) -> Result<(), String> {
-        let metadata = graph.metadata().ok_or(
+        let metadata = graph.metadata().ok_or_else(||
             String::from("The graph does not contain metadata")
         )?;
 
@@ -870,7 +870,7 @@ impl GAFBase {
         // `insert_alignments` consumes the connection, as it is moved to another thread.
         let connection = Connection::open(&db_file).map_err(|x| x.to_string())?;
         let built_index = Self::insert_alignments(index.clone(), gaf_file, connection, params)?;
-        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
+        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or_else(|| String::from("unknown")));
         let actual_index = match (&index, &built_index) {
             (Some(index), None) => index.as_ref(),
             (None, Some(index)) => index,
@@ -879,10 +879,10 @@ impl GAFBase {
 
         let mut connection = Connection::open(&db_file).map_err(|x| x.to_string())?;
         let nodes = Self::insert_nodes(actual_index, graph, &mut connection)?;
-        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
+        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or_else(|| String::from("unknown")));
 
         Self::insert_tags(actual_index, nodes, &aln_name, &mut connection, params)?;
-        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
+        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or_else(|| String::from("unknown")));
 
         Ok(())
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1040,11 +1040,7 @@ impl GAFBase {
         let (to_report, from_insert) = mpsc::sync_channel(1);
 
         // Encoder thread.
-        let expected_alignments = if let Some(index) = index.as_ref() {
-            Some(Self::gbwt_paths(index.as_ref()))
-        } else {
-            None
-        };
+        let expected_alignments = index.as_ref().map(|index| Self::gbwt_paths(index.as_ref()));
         let build_gbwt = index.is_none();
         let encoder_thread = thread::spawn(move || {
             let mut alignment_id = 0;
@@ -1182,12 +1178,11 @@ impl GAFBase {
             );
             match aln {
                 Ok(aln) => {
-                    if let Some(builder) = &mut builder {
-                        if let Err(msg) = builder.insert(aln.target_path().unwrap(), None) {
-                            let _ = to_encoder.send(Err(msg));
-                            failed = true;
-                            break;
-                        }
+                    if let Some(builder) = &mut builder
+                        && let Err(msg) = builder.insert(aln.target_path().unwrap(), None) {
+                        let _ = to_encoder.send(Err(msg));
+                        failed = true;
+                        break;
                     }
                     let mut aln = aln;
                     if !params.store_quality_strings {
@@ -1244,10 +1239,8 @@ impl GAFBase {
         let statistics = from_insert.recv().unwrap()?;
 
         eprintln!("Inserted information on {} alignments", statistics.alignments);
-        if let Some(expected_alignments) = expected_alignments {
-            if statistics.alignments != expected_alignments {
-                eprintln!("Warning: Expected {} alignments", expected_alignments);
-            }
+        if let Some(expected_alignments) = expected_alignments && statistics.alignments != expected_alignments {
+            eprintln!("Warning: Expected {} alignments", expected_alignments);
         }
         eprintln!(
             "Field sizes: gbwt_starts {}, names {}, quality_strings {}, difference_strings {}, flags {}, numbers {}, optional {}",

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,8 +1,8 @@
 //! GBZ-base and GAF-base: SQLite databases storing a GBZ graph and sequence alignments to the graph.
 
 use crate::{Alignment, AlignmentBlock, Chains};
-use crate::formats::JSONValue;
-use crate::{formats, utils};
+use crate::formats::{self, JSONValue};
+use crate::utils::{self, PathStartSource};
 
 use std::io::BufRead;
 use std::path::Path;
@@ -471,6 +471,8 @@ impl GBZBase {
 
 //-----------------------------------------------------------------------------
 
+// FIXME: Implement and document GBWT construction.
+// FIXME: Tests and examples that build a GBWT instead of loading it.
 /// A database connection to a GAF-base database.
 ///
 /// This structure stores a database connection and some header information.
@@ -759,7 +761,7 @@ impl Default for GAFBaseParams {
 
 //-----------------------------------------------------------------------------
 
-// TODO: Once we have GBWT construction in the gbz crate, we can build the GBWT in the background
+// FIXME: Once we have GBWT construction in the gbz crate, we can build the GBWT in the background
 // and insert it into the database after alignments. We can determine GBWT starting positions for
 // the alignments in advance. We know the node from the path, and we know the GBWT sequence id
 // from alignment id. GBWT path starts come from the endmarker, and they are therefore before all
@@ -767,10 +769,10 @@ impl Default for GAFBaseParams {
 // the GBWT starting position is (v, i).
 
 // TODO: If we are willing to use a reference, we could reuse `edges` in the `Nodes` table from it.
-// We can similarly speed up GBWT construction by having the GBWT of the graph available.
 
 /// Creating the database.
 impl GAFBase {
+    // FIXME: make GBWT optional
     /// Creates a new database from the [`GBWT`] index in file `gbwt_file` and stores the database in file `db_file`.
     ///
     /// The GBWT index can be forward-only or bidirectional.
@@ -805,6 +807,7 @@ impl GAFBase {
         Self::create(gaf_file, index, db_file, graph, params)
     }
 
+    // FIXME: make GBWT optional
     /// Creates a new database in file `filename` from the given [`GBWT`] index.
     ///
     /// The GBWT index can be forward-only or bidirectional.
@@ -862,8 +865,9 @@ impl GAFBase {
         Self::insert_tags(&index, nodes, &aln_name, &mut connection, params)?;
         eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
 
+        // FIXME: this should be the first insert function
         // `insert_alignments` consumes the connection, as it is moved to another thread.
-        Self::insert_alignments(index, gaf_file, connection, params)?;
+        let _built_index = Self::insert_alignments(Some(index.clone()), gaf_file, connection, params)?;
         eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
 
         Ok(())
@@ -973,7 +977,13 @@ impl GAFBase {
         Ok(inserted / 2)
     }
 
-    fn insert_alignments(index: Arc<GBWT>, gaf_file: Box<dyn BufRead>, connection: Connection, params: &GAFBaseParams) -> Result<(), String> {
+    // FIXME: This should build and return a GBWT index if not provided with one.
+    fn insert_alignments(
+        index: Option<Arc<GBWT>>,
+        gaf_file: Box<dyn BufRead>,
+        connection: Connection,
+        params: &GAFBaseParams
+    ) -> Result<Option<GBWT>, String> {
         eprintln!("Inserting alignments");
         let mut gaf_file = gaf_file;
         let mut connection = connection;
@@ -1015,15 +1025,24 @@ impl GAFBase {
         let (to_report, from_insert) = mpsc::sync_channel(1);
 
         // Encoder thread.
-        let gbwt_index = index.clone();
+        let expected_alignments = if let Some(index) = index.as_ref() {
+            Some(Self::gbwt_paths(index.as_ref()))
+        } else {
+            None
+        };
         let encoder_thread = thread::spawn(move || {
             let mut alignment_id = 0;
+            let mut source = if let Some(index) = index.as_ref() {
+                PathStartSource::from(index.as_ref())
+            } else {
+                PathStartSource::new()
+            };
             loop {
                 // This can only fail if the sender is disconnected.
                 let block: Result<Vec<Alignment>, String> = from_parser.recv().unwrap();
                 match block {
                     Ok(block) => {
-                        let encoded = AlignmentBlock::new(&block, &gbwt_index, alignment_id);
+                        let encoded = AlignmentBlock::new(&block, &mut source, alignment_id);
                         match encoded {
                             Ok(data) => {
                                 let _ = to_insert.send(Ok(data));
@@ -1180,9 +1199,10 @@ impl GAFBase {
         let statistics = from_insert.recv().unwrap()?;
 
         eprintln!("Inserted information on {} alignments", statistics.alignments);
-        let expected_alignments = Self::gbwt_paths(&index);
-        if statistics.alignments != expected_alignments {
-            eprintln!("Warning: Expected {} alignments", expected_alignments);
+        if let Some(expected_alignments) = expected_alignments {
+            if statistics.alignments != expected_alignments {
+                eprintln!("Warning: Expected {} alignments", expected_alignments);
+            }
         }
         eprintln!(
             "Field sizes: gbwt_starts {}, names {}, quality_strings {}, difference_strings {}, flags {}, numbers {}, optional {}",
@@ -1195,7 +1215,7 @@ impl GAFBase {
             utils::human_readable_size(statistics.optional_bytes),
         );
 
-        Ok(())
+        Ok(None)
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,7 +11,7 @@ use std::{fs, thread};
 
 use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Statement};
 
-use gbz::{FullPathName, GBWT, GBZ, Orientation, Pos};
+use gbz::{FullPathName, GBWT, GBWTBuilder, GBZ, Orientation, Pos};
 use gbz::bwt::{BWT, Record};
 use gbz::support::{self, Tags};
 
@@ -471,8 +471,7 @@ impl GBZBase {
 
 //-----------------------------------------------------------------------------
 
-// FIXME: Implement and document GBWT construction.
-// FIXME: Tests and examples that build a GBWT instead of loading it.
+// FIXME: Tests that build a GBWT instead of loading it.
 /// A database connection to a GAF-base database.
 ///
 /// This structure stores a database connection and some header information.
@@ -487,13 +486,13 @@ impl GBZBase {
 /// use simple_sds::serialize;
 ///
 /// let gaf_file = utils::get_test_data("micb-kir3dl1_HG003.gaf.gz");
-/// let gbwt_file = utils::get_test_data("micb-kir3dl1_HG003.gbwt");
+/// let gbwt_file = None; // Build a new GBWT index.
 /// let db_file = serialize::temp_file_name("gaf-base");
 ///
-/// // Create the database.
+/// // Create a database that requires a reference graph to use.
 /// let graph = GraphReference::None;
 /// let params = GAFBaseParams::default();
-/// let db = GAFBase::create_from_files(&gaf_file, &gbwt_file, &db_file, graph, &params);
+/// let db = GAFBase::create_from_files(&gaf_file, gbwt_file, &db_file, graph, &params);
 /// assert!(db.is_ok());
 ///
 /// // Now open it and check some statistics.
@@ -705,6 +704,12 @@ pub struct GAFBaseParams {
     /// Note that values `0` and `1` are functionally equivalent.
     pub block_size: usize,
 
+    /// GBWT construction buffer size in nodes.
+    ///
+    /// Default: [`Self::GBWT_BUFFER_SIZE`].
+    /// Note that the buffer grows automatically if a path is longer than the initial buffer size.
+    pub gbwt_buffer_size: usize,
+
     /// Build a reference-free GAF-base that stores sequences in table `Nodes`.
     ///
     /// Default: `false`.
@@ -724,6 +729,9 @@ pub struct GAFBaseParams {
 impl GAFBaseParams {
     /// Default block size in alignments.
     pub const BLOCK_SIZE: usize = 1000;
+
+    /// Default GBWT construction buffer size in nodes.
+    pub const GBWT_BUFFER_SIZE: usize = 100_000_000;
 
     // TODO: from_json
 
@@ -752,6 +760,7 @@ impl Default for GAFBaseParams {
     fn default() -> Self {
         Self {
             block_size: Self::BLOCK_SIZE,
+            gbwt_buffer_size: Self::GBWT_BUFFER_SIZE,
             reference_free: false,
             store_quality_strings: true,
             store_optional_fields: true,
@@ -761,28 +770,23 @@ impl Default for GAFBaseParams {
 
 //-----------------------------------------------------------------------------
 
-// FIXME: Once we have GBWT construction in the gbz crate, we can build the GBWT in the background
-// and insert it into the database after alignments. We can determine GBWT starting positions for
-// the alignments in advance. We know the node from the path, and we know the GBWT sequence id
-// from alignment id. GBWT path starts come from the endmarker, and they are therefore before all
-// other path visits to that node. If a path is the (i+1)-th path starting from GBWT node v,
-// the GBWT starting position is (v, i).
-
 // TODO: If we are willing to use a reference, we could reuse `edges` in the `Nodes` table from it.
 
 /// Creating the database.
 impl GAFBase {
-    // FIXME: make GBWT optional
-    /// Creates a new database from the [`GBWT`] index in file `gbwt_file` and stores the database in file `db_file`.
+    /// Creates a new database from the alignments in file `gaf_file` and stores the database in file `db_file`.
     ///
-    /// The GBWT index can be forward-only or bidirectional.
+    /// A unidirectional or bidirectional GBWT index can be provided in file `gbwt_file`.
     /// Path `i` in the GBWT index corresponds to line `i` in the GAF file.
+    /// If a GBWT file is not provided, a new unidirectional index will be built in the background.
+    /// This will use a significant amount of memory, but it should not be the bottleneck of the construction.
+    ///
     /// If the parameters indicate that node sequences should be stored in the database, a GBZ-compatible graph must be provided.
     ///
     /// # Arguments
     ///
     /// * `gaf_file`: GAF file storing the alignments. Can be gzip-compressed.
-    /// * `gbwt_file`: GBWT file storing the target paths.
+    /// * `gbwt_file`: An optional GBWT file storing the target paths.
     /// * `db_file`: Output database file.
     /// * `graph`: A GBZ-compatible graph for building a reference-free database, or [`GraphReference::None`] for a reference-based one.
     /// * `params`: Construction parameters.
@@ -796,28 +800,34 @@ impl GAFBase {
     /// * Trying to build a reference-free GAF-base without a graph.
     /// * The graph is not a valid reference for the alignments.
     ///
-    /// Passes through any database errors.
+    /// Passes through any I/O, database, and construction errors.
     pub fn create_from_files(
-        gaf_file: &Path, gbwt_file: &Path, db_file: &Path,
+        gaf_file: &Path, gbwt_file: Option<&Path>, db_file: &Path,
         graph: GraphReference<'_, '_>,
         params: &GAFBaseParams
     ) -> Result<(), String> {
-        eprintln!("Loading GBWT index {}", gbwt_file.display());
-        let index: Arc<GBWT> = Arc::new(serialize::load_from(gbwt_file).map_err(|x| x.to_string())?);
-        Self::create(gaf_file, index, db_file, graph, params)
+        if let Some(gbwt_file) = gbwt_file {
+            eprintln!("Loading GBWT index {}", gbwt_file.display());
+            let index: Arc<GBWT> = Arc::new(serialize::load_from(gbwt_file).map_err(|x| x.to_string())?);
+            Self::create(gaf_file, Some(index), db_file, graph, params)
+        } else {
+            Self::create(gaf_file, None, db_file, graph, params)
+        }
     }
 
-    // FIXME: make GBWT optional
-    /// Creates a new database in file `filename` from the given [`GBWT`] index.
+    /// Creates a new database from the alignments in file `gaf_file` and stores the database in file `db_file`.
     ///
-    /// The GBWT index can be forward-only or bidirectional.
+    /// A unidirectional or bidirectional GBWT index can be provided.
     /// Path `i` in the GBWT index corresponds to line `i` in the GAF file.
+    /// If a GBWT index is not provided, a new unidirectional index will be built in the background.
+    /// This will use a significant amount of memory, but it should not be the bottleneck of the construction.
+    ///
     /// If the parameters indicate that node sequences should be stored in the database, a GBZ-compatible graph must be provided.
     ///
     /// # Arguments
     ///
     /// * `gaf_file`: GAF file storing the alignments. Can be gzip-compressed.
-    /// * `index`: GBWT index storing the target paths.
+    /// * `index`: An optional GBWT index storing the target paths.
     /// * `db_file`: Output database file.
     /// * `graph`: A GBZ-compatible graph for building a reference-free database, or [`GraphReference::None`] for a reference-based one.
     /// * `params`: Construction parameters.
@@ -831,9 +841,9 @@ impl GAFBase {
     /// * Trying to build a reference-free GAF-base without a graph.
     /// * The graph is not a valid reference for the alignments.
     ///
-    /// Passes through any database errors.
+    /// Passes through any I/O, database, and construction errors.
     pub fn create<P: AsRef<Path>, Q: AsRef<Path>>(
-        gaf_file: P, index: Arc<GBWT>, db_file: Q,
+        gaf_file: P, index: Option<Arc<GBWT>>, db_file: Q,
         graph: GraphReference<'_, '_>,
         params: &GAFBaseParams
     ) -> Result<(), String> {
@@ -858,16 +868,21 @@ impl GAFBase {
         let graph_name = graph.graph_name()?;
         utils::require_valid_reference(&aln_name, &graph_name)?;
 
-        let mut connection = Connection::open(&db_file).map_err(|x| x.to_string())?;
-        let nodes = Self::insert_nodes(&index, graph, &mut connection)?;
-        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
-
-        Self::insert_tags(&index, nodes, &aln_name, &mut connection, params)?;
-        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
-
-        // FIXME: this should be the first insert function
         // `insert_alignments` consumes the connection, as it is moved to another thread.
-        let _built_index = Self::insert_alignments(Some(index.clone()), gaf_file, connection, params)?;
+        let connection = Connection::open(&db_file).map_err(|x| x.to_string())?;
+        let built_index = Self::insert_alignments(index.clone(), gaf_file, connection, params)?;
+        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
+        let actual_index = match (&index, &built_index) {
+            (Some(index), None) => index.as_ref(),
+            (None, Some(index)) => index,
+            _ => return Err(String::from("Logic error in GBWT handling")),
+        };
+
+        let mut connection = Connection::open(&db_file).map_err(|x| x.to_string())?;
+        let nodes = Self::insert_nodes(actual_index, graph, &mut connection)?;
+        eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
+
+        Self::insert_tags(actual_index, nodes, &aln_name, &mut connection, params)?;
         eprintln!("Database size: {}", utils::file_size(&db_file).unwrap_or(String::from("unknown")));
 
         Ok(())
@@ -977,7 +992,7 @@ impl GAFBase {
         Ok(inserted / 2)
     }
 
-    // FIXME: This should build and return a GBWT index if not provided with one.
+    // This returns a GBWT index on success if and only if one was not provided.
     fn insert_alignments(
         index: Option<Arc<GBWT>>,
         gaf_file: Box<dyn BufRead>,
@@ -1019,7 +1034,8 @@ impl GAFBase {
         // The main thread parses the GAF file and sends blocks of alignments to an encoder thread.
         // That thread sends the encoded blocks to a third thread that inserts them into the database.
         // If something fails within a thread, it sends an error message to the next thread and stops.
-        // If a thread receives an error message, it passes it through and stops.
+        // If a thread receives an error message, it passes it through and stops. If a thread fails to
+        // send an `Ok` message, it indicates that the receiver has already reported an error and stopped.
         let (to_encoder, from_parser) = mpsc::sync_channel(4);
         let (to_insert, from_encoder) = mpsc::sync_channel(4);
         let (to_report, from_insert) = mpsc::sync_channel(1);
@@ -1030,6 +1046,7 @@ impl GAFBase {
         } else {
             None
         };
+        let build_gbwt = index.is_none();
         let encoder_thread = thread::spawn(move || {
             let mut alignment_id = 0;
             let mut source = if let Some(index) = index.as_ref() {
@@ -1045,7 +1062,10 @@ impl GAFBase {
                         let encoded = AlignmentBlock::new(&block, &mut source, alignment_id);
                         match encoded {
                             Ok(data) => {
-                                let _ = to_insert.send(Ok(data));
+                                // Failure to send indicates that the receiver has already failed.
+                                if to_insert.send(Ok(data)).is_err() {
+                                    return;
+                                }
                             },
                             Err(message) => {
                                 let _ = to_insert.send(Err(message));
@@ -1125,11 +1145,18 @@ impl GAFBase {
         });
 
         // TODO: Maybe we should start a new block when the min node changes and the block is large enough.
-        // Main thread that parses the alignments.
+        // Main thread that parses the alignments and builds a GBWT index in
+        // the background if needed. If we get an error in this thread, we pass
+        // it through the other threads and stop.
         let mut line_num: usize = 0;
         let mut unaligned_block = false;
         let mut block: Vec<Alignment> = Vec::new();
         let mut failed = false;
+        let mut builder = if build_gbwt {
+            Some(GBWTBuilder::new(false, false, params.gbwt_buffer_size))
+        } else {
+            None
+        };
         loop {
             let mut buf: Vec<u8> = Vec::new();
             let len = gaf_file.read_until(b'\n', &mut buf).map_err(|x| x.to_string());
@@ -1156,6 +1183,13 @@ impl GAFBase {
             );
             match aln {
                 Ok(aln) => {
+                    if let Some(builder) = &mut builder {
+                        if let Err(msg) = builder.insert(aln.target_path().unwrap(), None) {
+                            let _ = to_encoder.send(Err(msg));
+                            failed = true;
+                            break;
+                        }
+                    }
                     let mut aln = aln;
                     if !params.store_quality_strings {
                         aln.base_quality.clear();
@@ -1166,14 +1200,24 @@ impl GAFBase {
                     if aln.is_unaligned() != unaligned_block {
                         // We have a new block.
                         if !block.is_empty() {
-                            let _ = to_encoder.send(Ok(block));
+                            // Failure to send indicates that the receiver has already failed.
+                            if to_encoder.send(Ok(block)).is_err() {
+                                block = Vec::new();
+                                failed = true;
+                                break;
+                            }
                             block = Vec::new();
                         }
                         unaligned_block = aln.is_unaligned();
                     }
                     block.push(aln);
                     if block.len() >= params.block_size {
-                        let _ = to_encoder.send(Ok(block));
+                        // Failure to send indicates that the receiver has already failed.
+                        if to_encoder.send(Ok(block)).is_err() {
+                            block = Vec::new();
+                            failed = true;
+                            break;
+                        }
                         block = Vec::new();
                     }
                 },
@@ -1189,6 +1233,8 @@ impl GAFBase {
         // Send the last block and a termination signal.
         // Then wait for the threads to finish and get the number of inserted alignments.
         if !failed {
+            // If we fail here, the other threads have already failed, and we will get
+            // an error message from `from_insert`.
             if !block.is_empty() {
                 let _ = to_encoder.send(Ok(block));
             }
@@ -1215,7 +1261,15 @@ impl GAFBase {
             utils::human_readable_size(statistics.optional_bytes),
         );
 
-        Ok(None)
+        // Finally build the GBWT index.
+        if let Some(builder) = builder {
+            eprintln!("Finishing GBWT construction");
+            let index = builder.build()?;
+            eprintln!("GBWT index: {} sequences of total length {}", index.sequences(), index.len());
+            Ok(Some(index))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -534,6 +534,24 @@ fn gaf_base_gz_bidirectional() {
 }
 
 #[test]
+fn gaf_base_build_gbwt() {
+    // Lower the buffer size to make the test non-trivial to avoid allocating large buffers.
+    let mut params = GAFBaseParams::default();
+    params.gbwt_buffer_size = 10000;
+
+    let db_file = internal::create_gaf_base_with_params(
+        "micb-kir3dl1_HG003.gaf", "",
+        GraphReference::None, &params
+    );
+    let db = internal::open_gaf_base(&db_file);
+    check_gaf_base(&db, UNIDIRECTIONAL_NODES, ALIGNMENTS, BLOCKS, false);
+    check_gaf_base_tags(&db, 1);
+
+    drop(db);
+    let _ = std::fs::remove_file(&db_file);
+}
+
+#[test]
 fn gaf_base_no_quality() {
     let mut params = GAFBaseParams::default();
     params.store_quality_strings = false;

--- a/src/gaf_sort.rs
+++ b/src/gaf_sort.rs
@@ -267,6 +267,11 @@ impl SortParameters {
     /// Default for `buffer_size`.
     pub const DEFAULT_BUFFER_SIZE: usize = 1000;
 
+    /// Returns a new `SortParameters` with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Validates the parameters and returns an error message if they are invalid.
     pub fn validate(&self) -> Result<(), String> {
         if self.records_per_file == 0 {

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -55,7 +55,7 @@ pub(crate) fn create_gaf_base_with_params(gaf_part: &'static str, gbwt_part: &'s
     let gaf_file = utils::get_test_data(gaf_part);
     let gbwt_file = utils::get_test_data(gbwt_part);
     let db_file = serialize::temp_file_name("gaf-base");
-    let result = GAFBase::create_from_files(&gaf_file, &gbwt_file, &db_file, graph, params);
+    let result = GAFBase::create_from_files(&gaf_file, Some(&gbwt_file), &db_file, graph, params);
     assert!(result.is_ok(), "Failed to create GAF-base database: {}", result.unwrap_err());
     db_file
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -47,15 +47,21 @@ pub(crate) fn create_graph_interface(database: &GBZBase) -> GraphInterface<'_> {
 
 // GAF-base utilities.
 
+// If `gbwt_part` is empty, build a new GBWT index.
 pub(crate) fn create_gaf_base(gaf_part: &'static str, gbwt_part: &'static str) -> PathBuf {
     create_gaf_base_with_params(gaf_part, gbwt_part, GraphReference::None, &GAFBaseParams::default())
 }
 
+// If `gbwt_part` is empty, build a new GBWT index.
 pub(crate) fn create_gaf_base_with_params(gaf_part: &'static str, gbwt_part: &'static str, graph: GraphReference<'_, '_>, params: &GAFBaseParams) -> PathBuf {
     let gaf_file = utils::get_test_data(gaf_part);
-    let gbwt_file = utils::get_test_data(gbwt_part);
+    let gbwt_file = if gbwt_part.is_empty() {
+        None
+    } else {
+        Some(utils::get_test_data(gbwt_part))
+    };
     let db_file = serialize::temp_file_name("gaf-base");
-    let result = GAFBase::create_from_files(&gaf_file, Some(&gbwt_file), &db_file, graph, params);
+    let result = GAFBase::create_from_files(&gaf_file, gbwt_file.as_deref(), &db_file, graph, params);
     assert!(result.is_ok(), "Failed to create GAF-base database: {}", result.unwrap_err());
     db_file
 }

--- a/src/read_set.rs
+++ b/src/read_set.rs
@@ -352,8 +352,7 @@ impl ReadSet {
     /// Passes through any database errors.
     /// Returns an error if an alignment cannot be decompressed.
     pub fn from_rows(database: &GAFBase, row_range: Range<usize>, graph: Option<&GBZ>) -> Result<Self, String> {
-        let mut read_set = ReadSet::default();
-        read_set.clusters = 1;
+        let mut read_set = ReadSet { clusters: 1, ..Default::default() };
 
         // Build a record from the GAF-base, with the sequence possibly from the GBZ graph.
         let mut get_node = database.connection.prepare(

--- a/src/read_set.rs
+++ b/src/read_set.rs
@@ -72,11 +72,11 @@ impl Display for AlignmentOutput {
 ///
 /// // Create a database of reads aligned to the graph.
 /// let gaf_file = utils::get_test_data("micb-kir3dl1_HG003.gaf");
-/// let gbwt_file = utils::get_test_data("micb-kir3dl1_HG003.gbwt");
+/// let gbwt_file = None; // Build a new GBWT index.
 /// let db_file = serialize::temp_file_name("gaf-base");
 /// let graph_ref = GraphReference::None; // Do not store sequences in the database.
 /// let params = GAFBaseParams::default();
-/// let db = GAFBase::create_from_files(&gaf_file, &gbwt_file, &db_file, graph_ref, &params);
+/// let db = GAFBase::create_from_files(&gaf_file, gbwt_file, &db_file, graph_ref, &params);
 /// assert!(db.is_ok());
 ///
 /// // Extract all reads fully within the subgraph.

--- a/src/read_set.rs
+++ b/src/read_set.rs
@@ -378,7 +378,7 @@ impl ReadSet {
             let (edges, bwt, mut sequence) = gaf_result.unwrap();
             if sequence.is_empty() {
                 if let Some(graph) = graph {
-                    let seq = graph.sequence(support::node_id(handle)).ok_or(
+                    let seq = graph.sequence(support::node_id(handle)).ok_or_else(||
                         format!("Could not find the sequence for handle {} in GBZ", handle)
                     )?;
                     sequence = seq.to_vec();

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -218,14 +218,14 @@ impl Subgraph {
         path_index: &PathIndex,
         query_pos: &FullPathName
     ) -> Result<(PathPosition, FullPathName), String> {
-        let path = GBZPath::with_name(graph, query_pos).ok_or(
+        let path = GBZPath::with_name(graph, query_pos).ok_or_else(||
             format!("Cannot find a path covering {}", query_pos)
         )?;
         // Transform the offset relative to the haplotype to the offset relative to the path.
         let query_offset = query_pos.fragment - path.name.fragment;
 
         // Path id to an indexed position.
-        let index_offset = path_index.path_to_offset(path.handle).ok_or(
+        let index_offset = path_index.path_to_offset(path.handle).ok_or_else(||
             format!("Path {} has not been indexed for random access", path.name())
         )?;
         let (path_offset, pos) = path_index.indexed_position(index_offset, query_offset).unwrap();
@@ -301,7 +301,7 @@ impl Subgraph {
         query_pos: &FullPathName
     ) -> Result<(PathPosition, FullPathName), String> {
         let path = graph.find_path(query_pos)?;
-        let path = path.ok_or(format!("Cannot find a path covering {}", query_pos))?;
+        let path = path.ok_or_else(|| format!("Cannot find a path covering {}", query_pos))?;
         if !path.is_indexed {
             return Err(format!("Path {} has not been indexed for random access", query_pos));
         }
@@ -310,7 +310,7 @@ impl Subgraph {
 
         // Find an indexed position before the query position.
         let result = graph.indexed_position(path.handle, query_offset)?;
-        let (path_offset, pos) = result.ok_or(
+        let (path_offset, pos) = result.ok_or_else(||
             format!("Path {} has not been indexed for random access", path.name())
         )?;
 
@@ -351,7 +351,7 @@ impl Subgraph {
             pos = next.unwrap();
         }
 
-        let node_offset = node_offset.ok_or(
+        let node_offset = node_offset.ok_or_else(||
             format!("Path {} does not contain offset {}", path_name, query_offset)
         )?;
         let gbwt_pos = gbwt_pos.unwrap();
@@ -805,7 +805,7 @@ impl Subgraph {
         }
         match query.query_type() {
             QueryType::PathOffset(query_pos) => {
-                let path_index = path_index.ok_or(
+                let path_index = path_index.ok_or_else(||
                     String::from("Path index is required for path-based queries")
                 )?;
                 let reference_path = self.path_pos_from_gbz(graph, path_index, query_pos)?;
@@ -816,7 +816,7 @@ impl Subgraph {
                 self.extract_paths(Some(reference_path), query.output())?;
             },
             QueryType::PathInterval(query_pos, len) => {
-                let path_index = path_index.ok_or(
+                let path_index = path_index.ok_or_else(||
                     String::from("Path index is required for path-based queries")
                 )?;
                 let reference_path = self.path_pos_from_gbz(graph, path_index, query_pos)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 //! Utility functions and structures.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, File};
 use std::ops::{Range, RangeInclusive};
 use std::path::{Path, PathBuf};
@@ -8,7 +8,7 @@ use std::io::{self, BufRead, BufReader, Read, Error, ErrorKind};
 
 use flate2::read::MultiGzDecoder;
 
-use gbz::{support, Orientation};
+use gbz::{support, Orientation, GBWT, Pos, ENDMARKER};
 use pggname::GraphName;
 use simple_sds::int_vector::IntVector;
 use simple_sds::ops::{Vector, Access};
@@ -498,6 +498,65 @@ pub fn cluster_node_ids(node_ids: Vec<usize>, threshold: usize) -> Vec<RangeIncl
 
 //-----------------------------------------------------------------------------
 
+/// A structure that determines the GBWT starting positions for paths in a graph.
+///
+/// The starting positions are iterated in order.
+/// If a GBWT index is provided, the starting positions are determined from the paths in the index.
+/// Otherwise the starting positions for a unidirectional index are computed on the fly.
+pub enum PathStartSource<'a> {
+    /// A GBWT index of the paths and the next sequence id that has not been iterated.
+    Index(&'a GBWT, usize),
+    /// A map storing the number of paths starting from each node so far.
+    Map(HashMap<usize, usize>),
+}
+
+impl<'a> PathStartSource<'a> {
+    /// Returns a new source that computes the starting positions on the fly.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the starting position of the next path.
+    ///
+    /// If the source is a GBWT index, the provided node identifier is ignored.
+    /// Returns [`None`] if the path is empty or all paths in the index have been iterated.
+    ///
+    /// If the source is a map, returns the starting position that would be assigned to the next path starting from the given node.
+    /// Returns [`None`] if the path is empty (if the node identifier is [`ENDMARKER`]).
+    pub fn next(&mut self, node_id: usize) -> Option<Pos> {
+        match self {
+            Self::Index(index, seq_id) => {
+                let result = index.start(*seq_id);
+                *seq_id += if index.is_bidirectional() { 2 } else { 1 };
+                result
+            }
+            Self::Map(map) => {
+                if node_id == ENDMARKER {
+                    return None;
+                }
+                let count = map.entry(node_id).or_insert(0);
+                let result = Pos::new(node_id, *count);
+                *count += 1;
+                Some(result)
+            }
+        }
+    }
+}
+
+impl<'a> Default for PathStartSource<'a> {
+    fn default() -> Self {
+        Self::Map(HashMap::new())
+    }
+}
+
+impl<'a> From<&'a GBWT> for PathStartSource<'a> {
+    fn from(index: &'a GBWT) -> Self {
+        Self::Index(index, 0)
+    }
+}
+
+//-----------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -645,6 +704,43 @@ mod tests {
         let node_ids = vec![1, 50, 52, 53, 73, 74, 200];
         let expected = vec![1..=1, 50..=53, 73..=74, 200..=200];
         test_cluster(node_ids, expected, 10, "two clusters and outliers");
+    }
+
+    #[test]
+    fn path_start_source() {
+        let gbwt_files = vec![
+            get_test_data("micb-kir3dl1_HG003.gbwt"),
+            get_test_data("bidirectional.gbwt"),
+            get_test_data("empty.gbwt"),
+            support::get_test_data("example.gbwt"),
+            support::get_test_data("translation.gbwt"),
+            support::get_test_data("with-empty.gbwt"),
+        ];
+
+        for gbwt_file in gbwt_files.iter() {
+            let index = serialize::load_from(gbwt_file);
+            assert!(index.is_ok(), "Failed to load GBWT index from {}: {}", gbwt_file.display(), index.unwrap_err());
+            let index: GBWT = index.unwrap();
+
+            let paths = if index.is_bidirectional() {
+                index.sequences() / 2
+            } else {
+                index.sequences()
+            };
+            let mut index_source = PathStartSource::from(&index);
+            let mut map_source = PathStartSource::new();
+            for path_id in 0..paths {
+                let seq_id = if index.is_bidirectional() { support::encode_path(path_id, Orientation::Forward) } else { path_id };
+                let truth = index.start(seq_id);
+                let node_id = truth.map(|pos| pos.node).unwrap_or(ENDMARKER);
+                let index_pos = index_source.next(0);
+                assert_eq!(index_pos, truth, "Wrong path start from index for path {} in {}", path_id, gbwt_file.display());
+                if !index.is_bidirectional() {
+                    let map_pos = map_source.next(node_id);
+                    assert_eq!(map_pos, truth, "Wrong path start from map for path {} in {}", path_id, gbwt_file.display());
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
GAF-base can now be built without vg. If no GBWT index is provided, the construction will automatically build one in a background thread. This will increase the memory usage of construction. Construction time will remain the same, as the actual bottleneck is with inserting the alignments into the database. And because the GAF file can now be sorted without building a GBWT index during sorting, the overall construction will be faster.