### PR TITLE
Build chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ All other paths will be listed as unknown haplotypes.
 
 ### Other options
 
+* `--handle N`: Node-based query using handles (GBWT node identifiers) encoded as `2 * node_id + is_reverse`.
 * `--context N`: Extract `N` bp context around the query position (default: 100).
   Context length can be specified using suffixes such as `k` or `M`.
 * `--distinct`: Collapse identical paths in the subgraph and report the number of copies using `WT:i` tags.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ To build the package, run:
 cargo build --release
 ```
 
-You will then have the `gbz2db`, `gaf2db`, and `query` tool binaries in `target/release/`.
+You will then have the following binaries in `target/release/`:
+
+* `gbz2db`: Builds a GBZ-base.
+* `gaf2db`: Builds a GAF-base.
+* `db2gaf`: Converts GAF-base back to GAF.
+* `query`: Queries in GBZ-base and GAF-base.
+* `gafsort`: Sorts a GAF file for GAF-base construction.
 
 ## GBZ-base construction
 
@@ -41,7 +47,7 @@ Generic paths (with sample name `_gbwt_ref`) and reference paths (samples specif
 A GBZ-base stores links between the boundary nodes of snarls in top-level chains.
 Such links enable better subgraph queries (see below).
 By default, the `gbz2db` tries to find them using a simple algorithm that works with Minigraph–Cactus graphs.
-It requires that each graph component contains exactly two tips and that there is a path connecting the tips that visits all bridge nodes / articulation points.
+It requires that each graph component contains exactly two tips with a directed path between them.
 
 If the assumptions fail, the algorithm will not be able to find top-level chains for some components.
 In such cases, prebuilt chains can be used with option `--chains graph.chains`.

--- a/README.md
+++ b/README.md
@@ -36,12 +36,16 @@ An existing database can be overwritten with option `--overwrite`.
 The database will be functionally equivalent to the GBZ graph, except that it will not contain a node-to-segment translation.
 Generic paths (with sample name `_gbwt_ref`) and reference paths (samples specified in GBWT tag `reference_samples`) will be indexed for querying.
 
-### Including top-level chains
+### Precomputed top-level chains
 
-A GBZ-base can optionally store links between boundary nodes in top-level chains.
+A GBZ-base stores links between the boundary nodes of snarls in top-level chains.
 Such links enable better subgraph queries (see below).
-In order to build a database with top-level chains, you first need to extract the chains from a distance index or a snarls file.
-That requires [vg](https://github.com/vgteam/vg) version 1.69.0 or newer.
+By default, the `gbz2db` tries to find them using a simple algorithm that works with Minigraph–Cactus graphs.
+It requires that each graph component contains exactly two tips and that there is a path connecting the tips that visits all bridge nodes / articulation points.
+
+If the assumptions fail, the algorithm will not be able to find top-level chains for some components.
+In such cases, prebuilt chains can be used with option `--chains graph.chains`.
+[vg](https://github.com/vgteam/vg) version 1.69.0 or newer can extract a chains file from a distance index or a snarls file.
 
 Example with chains extracted from a distance index:
 
@@ -161,7 +165,7 @@ query --contig chrM --interval 3000..4000 --snarls graph.db > out.gfa
 
 After extracting a subgraph, the query determines all top-level snarls that have their boundary nodes in the extracted subgraph.
 Then it ensures that those snarls are fully in the subgraph.
-This requires either a GBZ-base built with top-level chains (see above) or a GBZ graph with a chains file provided with `--chains FILE`.
+These snarls are based on the top-level chains provided or computed during GBZ-base construction.
 
 ### Extracting alignments
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 * Database versions: GBZ-base v0.4.0, GAF-base version 3
 * GBZ-base and GAF-base construction without vg:
+  * GBZ-base construction will find top-level chains automatically if not provided.
   * GAF sorting with `gaf_sort()` and the `gafsort` tool.
   * GBWT construction in a background thread when building GAF-base.
 * Bug fixes:

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -1,4 +1,4 @@
-use gbz_base::{GBZBase, GraphInterface, GraphReference, PathIndex, Chains};
+use gbz_base::{GBZBase, GraphInterface, GraphReference, PathIndex};
 use gbz_base::{Subgraph, SubgraphQuery, HaplotypeOutput};
 use gbz_base::{GAFBase, ReadSet, AlignmentOutput};
 use gbz_base::{formats, utils};
@@ -30,7 +30,7 @@ fn main() -> Result<(), String> {
         let graph: GBZ = serialize::load_from(&config.filename).map_err(|x| x.to_string())?;
         let path_index = PathIndex::new(&graph, GBZBase::INDEX_INTERVAL, false)?;
         let chains = match &config.chains {
-            Some(file) => Some(Chains::load_from(file.as_ref())?),
+            Some(file) => Some(serialize::load_from(&file).map_err(|x| x.to_string())?),
             None => None,
         };
         subgraph.from_gbz(&graph, Some(&path_index), chains.as_ref(), &config.query)?;

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -153,6 +153,7 @@ impl Config {
         opts.optopt("o", "offset", "sequence offset", "INT");
         opts.optopt("i", "interval", "half-open sequence interval", "INT..INT");
         opts.optmulti("n", "node", "node identifier (may repeat)", "INT");
+        opts.optmulti("", "handle", "node corresponding to a handle (may repeat)", "INT");
         opts.optopt("b", "between", "subgraph between boundary nodes", "INT[+-]:INT[+-]");
         opts.optopt("", "limit", "safety limit for the number of nodes in -b", "INT");
         let context_desc = format!("context length in bp (not for -b; default: {})", Self::DEFAULT_CONTEXT);
@@ -168,7 +169,7 @@ impl Config {
         opts.optopt("", "alignments", "alignment selection (overlapping, clipped, or contained; default: clipped)", "STR");
         let matches = opts.parse(&args[1..]).map_err(|x| x.to_string())?;
 
-        let header = format!("Usage: {} [options] graph.gbz[.db]\n\nQuery type must be speficied using one of -o, -i, -n, and -b.", program);
+        let header = format!("Usage: {} [options] graph.gbz[.db]\n\nQuery type must be speficied using one of -o, -i, -n (or --handle), and -b.", program);
         if matches.opt_present("help") {
             eprint!("{}", opts.usage(&header));
             process::exit(0);
@@ -267,10 +268,10 @@ impl Config {
         let mut needs_path_name = false;
         if matches.opt_present("offset") { count += 1; needs_path_name = true; }
         if matches.opt_present("interval") { count += 1; needs_path_name = true; }
-        if matches.opt_present("node") { count += 1; }
+        if matches.opt_present("node") || matches.opt_present("handle") { count += 1; }
         if matches.opt_present("between") { count += 1; }
         if count != 1 {
-            return Err("Exactly one of --offset, --interval, --node, and --between must be provided".to_string());
+            return Err("Exactly one of --offset, --interval, --node (or --handle), and --between must be provided".to_string());
         }
 
         let path_name = if needs_path_name {
@@ -311,10 +312,15 @@ impl Config {
             SubgraphQuery::between(start, end, limit)
         } else {
             let node_strings = matches.opt_strs("node");
-            let mut nodes = Vec::with_capacity(node_strings.len());
+            let handle_strings = matches.opt_strs("handle");
+            let mut nodes = Vec::with_capacity(node_strings.len() + handle_strings.len());
             for node in node_strings {
                 let id = Self::parse_integer(&node, "node")?;
                 nodes.push(id);
+            }
+            for handle in handle_strings {
+                let id = Self::parse_integer(&handle, "handle")?;
+                nodes.push(support::node_id(id));
             }
             SubgraphQuery::nodes(nodes)
         };

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), String> {
         let graph: GBZ = serialize::load_from(&config.filename).map_err(|x| x.to_string())?;
         let path_index = PathIndex::new(&graph, GBZBase::INDEX_INTERVAL, false)?;
         let chains = match &config.chains {
-            Some(file) => Some(serialize::load_from(&file).map_err(|x| x.to_string())?),
+            Some(file) => Some(serialize::load_from(file).map_err(|x| x.to_string())?),
             None => None,
         };
         subgraph.from_gbz(&graph, Some(&path_index), chains.as_ref(), &config.query)?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -12,6 +12,7 @@ use std::{fs, thread};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Statement};
 
 use gbz::{FullPathName, GBWT, GBWTBuilder, GBZ, Orientation, Pos};
+use gbz::algorithms;
 use gbz::bwt::{BWT, Record};
 use gbz::support::{self, Tags, Chains};
 
@@ -42,7 +43,7 @@ mod tests;
 /// let gbz_file = support::get_test_data("example.gbz");
 /// let db_file = serialize::temp_file_name("gbz-base");
 /// assert!(!binaries::file_exists(&db_file));
-/// // Here we build a database without chains.
+/// // We find top-level chains from the graph instead of providing them in a separate file.
 /// let result = GBZBase::create_from_files(&gbz_file, None, &db_file);
 /// assert!(result.is_ok());
 ///
@@ -203,6 +204,8 @@ impl GBZBase {
     ///
     /// * `gbz_file`: Name of the file containing the GBZ graph.
     /// * `chains_file`: Name of the file containing top-level chains.
+    ///   If not provided, tries to find the chains using [`algorithms::find_chains`] that works with Minigraph–Cactus graphs.
+    ///   Use [`Self::create`] with empty chains to build a database without chains.
     /// * `db_file`: Name of the database file to be created.
     ///
     /// # Errors
@@ -216,7 +219,15 @@ impl GBZBase {
             eprintln!("Loading top-level chain file {}", filename.display());
             serialize::load_from(filename).map_err(|x| x.to_string())?
         } else {
-            Chains::new()
+            eprintln!("Finding top-level chains in the graph");
+            let chains = algorithms::find_chains(&graph);
+            let components = if let Some(components) = chains.components() {
+                components.to_string()
+            } else {
+                String::from("an unknown number of")
+            };
+            eprintln!("Found {} chains with {} links for {} component(s)", chains.len(), chains.links(), components);
+            chains
         };
         Self::create(&graph, &chains, db_file)
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 //! GBZ-base and GAF-base: SQLite databases storing a GBZ graph and sequence alignments to the graph.
 
-use crate::{Alignment, AlignmentBlock, Chains};
+use crate::{Alignment, AlignmentBlock};
 use crate::formats::{self, JSONValue};
 use crate::utils::{self, PathStartSource};
 
@@ -13,7 +13,7 @@ use rusqlite::{Connection, OpenFlags, OptionalExtension, Row, Statement};
 
 use gbz::{FullPathName, GBWT, GBWTBuilder, GBZ, Orientation, Pos};
 use gbz::bwt::{BWT, Record};
-use gbz::support::{self, Tags};
+use gbz::support::{self, Tags, Chains};
 
 use pggname::GraphName;
 
@@ -214,7 +214,7 @@ impl GBZBase {
         let graph: GBZ = serialize::load_from(gbz_file).map_err(|x| x.to_string())?;
         let chains = if let Some(filename) = chains_file {
             eprintln!("Loading top-level chain file {}", filename.display());
-            Chains::load_from(filename)?
+            serialize::load_from(filename).map_err(|x| x.to_string())?
         } else {
             Chains::new()
         };

--- a/src/db.rs
+++ b/src/db.rs
@@ -204,7 +204,7 @@ impl GBZBase {
     ///
     /// * `gbz_file`: Name of the file containing the GBZ graph.
     /// * `chains_file`: Name of the file containing top-level chains.
-    ///   If not provided, tries to find the chains using [`algorithms::find_chains`] that works with Minigraph–Cactus graphs.
+    ///   If not provided, this tries to find the chains using [`algorithms::find_chains`] that works with Minigraph–Cactus graphs.
     ///   Use [`Self::create`] with empty chains to build a database without chains.
     /// * `db_file`: Name of the database file to be created.
     ///
@@ -226,7 +226,7 @@ impl GBZBase {
             } else {
                 String::from("an unknown number of")
             };
-            eprintln!("Found {} chains with {} links for {} component(s)", chains.len(), chains.links(), components);
+            eprintln!("Found {} chains with {} links for {} components", chains.len(), chains.links(), components);
             chains
         };
         Self::create(&graph, &chains, db_file)

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -234,7 +234,7 @@ fn large_test_case() {
     let gbz_file = utils::get_test_data("micb-kir3dl1.gbz");
     let graph: GBZ = serialize::load_from(&gbz_file).unwrap();
     let chains_file = utils::get_test_data("micb-kir3dl1.chains");
-    let chains = Chains::load_from(&chains_file).unwrap();
+    let chains = serialize::load_from(&chains_file).unwrap();
 
     // Create and open the database and create a graph interface.
     let db_file = internal::create_gbz_base_from_graph(&graph, &chains);
@@ -386,7 +386,7 @@ fn visited_positions(gbwt: &GBWT, path_handle: usize) -> HashSet<Pos> {
 fn check_indexed_positions(gbz_file: &PathBuf, chains_file: Option<&PathBuf>, ref_samples: Vec<String>) {
     let graph: GBZ = serialize::load_from(gbz_file).unwrap();
     let chains = if let Some(chains_file) = chains_file {
-        Chains::load_from(chains_file).unwrap()
+        serialize::load_from(chains_file).unwrap()
     } else {
         Chains::new()
     };

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -211,7 +211,8 @@ fn create_from_file() {
     // Load the graph.
     let gbz_file = support::get_test_data("example.gbz");
     let graph: GBZ = serialize::load_from(&gbz_file).unwrap();
-    let chains = Chains::new();
+    // GBZ-base creation from files finds the chains if a chain file is not provided.
+    let chains = algorithms::find_chains(&graph);
 
     // Create and open the database and create a graph interface.
     let db_file = internal::create_gbz_base_from_files(&gbz_file, None);

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,10 +1,10 @@
 use crate::{GBZBase, GraphInterface, formats};
 use crate::{GAFBase, GAFBaseParams, GraphReference};
-use crate::{Alignment, PathIndex, Chains};
+use crate::{Alignment, PathIndex};
 use crate::utils;
 
 use gbz::GBZ;
-use gbz::support;
+use gbz::support::{self, Chains};
 
 use simple_sds::{binaries, serialize};
 
@@ -152,7 +152,7 @@ pub(crate) fn load_gbz_and_create_path_index(filename: &'static str, interval: u
 
 pub(crate) fn load_chains(filename: &'static str) -> Chains {
     let chains_file = utils::get_test_data(filename);
-    let chains = Chains::load_from(&chains_file);
+    let chains = serialize::load_from(&chains_file);
     if let Err(err) = chains {
         panic!("Failed to load chains from {}: {}", chains_file.display(), err);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,4 +70,3 @@ pub use path_index::PathIndex;
 pub use read_set::{ReadSet, AlignmentOutput};
 pub use subgraph::Subgraph;
 pub use subgraph::query::{SubgraphQuery, HaplotypeOutput};
-pub use utils::Chains;

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -7,7 +7,7 @@
 
 use crate::{GBZRecord, GBZPath};
 use crate::{GraphInterface, GraphReference};
-use crate::{PathIndex, Chains};
+use crate::PathIndex;
 use crate::{SubgraphQuery, HaplotypeOutput};
 use crate::subgraph::query::QueryType;
 use crate::formats::{self, WalkMetadata, JSONValue};
@@ -22,6 +22,7 @@ use std::cmp;
 
 use gbz::ENDMARKER;
 use gbz::{GBZ, GraphPosition, Orientation, Pos, FullPathName};
+use gbz::support::Chains;
 use gbz::{algorithms, support};
 
 use pggname::{Graph, GraphName};
@@ -697,8 +698,8 @@ impl Subgraph {
     ///
     /// ```
     /// use gbz::{GBZ, Orientation};
-    /// use gbz::support;
-    /// use gbz_base::{Chains, Subgraph, GraphReference};
+    /// use gbz::support::{self, Chains};
+    /// use gbz_base::{Subgraph, GraphReference};
     /// use gbz_base::utils;
     /// use simple_sds::serialize;
     /// use std::collections::BTreeSet;
@@ -706,7 +707,7 @@ impl Subgraph {
     /// let graph_file = support::get_test_data("example.gbz");
     /// let graph: GBZ = serialize::load_from(&graph_file).unwrap();
     /// let chains_file = utils::get_test_data("example.chains");
-    /// let chains = Chains::load_from(&chains_file).unwrap();
+    /// let chains: Chains = serialize::load_from(&chains_file).unwrap();
     ///
     /// // Extract the boundary nodes of a snarl as the initial subgraph.
     /// let mut subgraph = Subgraph::new();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,18 +1,15 @@
 //! Utility functions and structures.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::fs::File;
 use std::ops::{Range, RangeInclusive};
 use std::path::{Path, PathBuf};
-use std::io::{self, BufRead, BufReader, Read, Error, ErrorKind};
+use std::io::{self, BufRead, BufReader};
 
 use flate2::read::MultiGzDecoder;
 
-use gbz::{support, Orientation, GBWT, Pos, ENDMARKER};
+use gbz::{GBWT, Pos, ENDMARKER};
 use pggname::GraphName;
-use simple_sds::int_vector::IntVector;
-use simple_sds::ops::{Vector, Access};
-use simple_sds::serialize::Serialize;
 use simple_sds::binaries;
 
 //-----------------------------------------------------------------------------
@@ -213,169 +210,6 @@ pub fn require_valid_reference(alignments: &GraphName, reference: &GraphName) ->
 
 //-----------------------------------------------------------------------------
 
-// TODO: Find chains from a graph:
-// 1. Find all weakly connected components.
-// 2. For each component (in parallel?):
-//    a. Build a tree of biconnected components.
-//    b. Find the longest path in the tree, upweighting the nodes on reference paths.
-//    c. Use the longest path as a chain.
-// TODO: Move to gbwt-rs?
-/// A set of top-level chains represented as links between boundary nodes.
-///
-/// Top-level chains provide a linear high-level structure for each weakly connected component in the graph.
-/// A chain is a sequence of nodes and snarls.
-/// Boundary nodes bordering the snarls form a sketch of graph topology.
-/// Given a pair of boundary nodes, the graph region between them is either a unary path or a snarl.
-/// In both cases, no path can leave the region without visiting one of the boundary nodes.
-///
-/// This representation is based on storing links between successive boundary nodes.
-/// Each link is stored twice, once in each orientation.
-///
-/// # Examples
-///
-/// ```
-/// use gbz_base::Chains;
-/// use gbz_base::utils;
-/// use gbz::support::{self, Orientation};
-///
-/// let filename = utils::get_test_data("micb-kir3dl1.chains");
-/// let chains = Chains::load_from(&filename);
-/// assert!(chains.is_ok());
-/// let chains = chains.unwrap();
-///
-/// assert_eq!(chains.len(), 2);
-/// assert_eq!(chains.links(), 925);
-/// let handle = support::encode_node(44, Orientation::Forward);
-/// assert!(chains.has_handle(handle));
-/// let next = support::encode_node(47, Orientation::Forward);
-/// assert_eq!(chains.next(handle), Some(next));
-/// ```
-pub struct Chains {
-    chains: usize,
-    next: BTreeMap<usize, usize>,
-}
-
-impl Chains {
-    // Reads the serialized chains representation.
-    fn read_data<R: Read>(reader: &mut R) -> io::Result<Vec<IntVector>> {
-        let chains = usize::load(reader)?;
-        let mut data: Vec<IntVector> = Vec::with_capacity(chains);
-        for _ in 0..chains {
-            let vec = IntVector::load(reader)?;
-            data.push(vec);
-        }
-        Ok(data)
-    }
-
-    // Converts the chains to a bidirectional link map.
-    fn link_map(data: Vec<IntVector>) -> io::Result<BTreeMap<usize, usize>> {
-        let mut next = BTreeMap::new();
-        for chain in data {
-            for i in 1..chain.len() {
-                let from = chain.get(i - 1) as usize;
-                if next.contains_key(&from) {
-                    let msg = format!("Duplicate link from {}", from);
-                    return Err(Error::new(ErrorKind::InvalidData, msg));
-                }
-                let to = chain.get(i) as usize;
-                next.insert(from, to);
-
-                let rev_from = support::flip_node(to);
-                if next.contains_key(&rev_from) {
-                    let msg = format!("Duplicate link from {}", rev_from);
-                    return Err(Error::new(ErrorKind::InvalidData, msg));
-                }
-                let rev_to = support::flip_node(from);
-                next.insert(rev_from, rev_to);
-            }
-        }
-        Ok(next)
-    }
-
-    /// Creates an empty set of chains.
-    pub fn new() -> Self {
-        Self {
-            chains: 0,
-            next: BTreeMap::new(),
-        }
-    }
-
-    /// Reads the chains from a reader in binary format.
-    ///
-    /// # Errors
-    ///
-    /// Passes through all deserialization errors.
-    /// Returns an error if a handle occurs in multiple chains.
-    pub fn deserialize<R: Read>(reader: &mut R) -> io::Result<Self> {
-        let data = Self::read_data(reader)?;
-        let chains = data.len();
-        let next = Self::link_map(data)?;
-        Ok(Self { chains, next })
-    }
-
-    /// Reads the chains from a binary file.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the file cannot be opened or [`Self::deserialize`] fails.
-    pub fn load_from(filename: &Path) -> Result<Self, String> {
-        let mut file = File::open(filename).map_err(|x|
-            format!("Failed to open chains file {}: {}", filename.display(), x)
-        )?;
-        Self::deserialize(&mut file).map_err(|x|
-            format!("Failed to read chains from file {}: {}", filename.display(), x)
-        )
-    }
-
-    /// Returns the number of chains.
-    pub fn len(&self) -> usize {
-        self.chains
-    }
-
-    /// Returns `true` if there are no chains.
-    pub fn is_empty(&self) -> bool {
-        self.chains == 0
-    }
-
-    /// Returns the total number of links in the chains.
-    pub fn links(&self) -> usize {
-        self.next.len() / 2
-    }
-
-    /// Returns the successor for the given handle in the chains, or [`None`] if there is no successor.
-    pub fn next(&self, handle: usize) -> Option<usize> {
-        self.next.get(&handle).copied()
-    }
-
-    /// Returns `true` if the given node is a boundary node in one of the chains.
-    pub fn has_node(&self, node_id: usize) -> bool {
-        let fw_handle = support::encode_node(node_id, Orientation::Forward);
-        let rev_handle = support::encode_node(node_id, Orientation::Reverse);
-        self.next.contains_key(&fw_handle) || self.next.contains_key(&rev_handle)
-    }
-
-    /// Returns `true` if the given handle refers to a boundary node.
-    pub fn has_handle(&self, handle: usize) -> bool {
-        let rev_handle = support::flip_node(handle);
-        self.next.contains_key(&handle) || self.next.contains_key(&rev_handle)
-    }
-
-    /// Returns an iterator over the links, ordered by source handle.
-    ///
-    /// Filter using [`support::encoded_edge_is_canonical`] to visit each link in a single orientation.
-    pub fn iter(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
-        self.next.iter().map(|(k, v)| (*k, *v))
-    }
-}
-
-impl Default for Chains {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-//-----------------------------------------------------------------------------
-
 #[derive(Clone, Debug)]
 struct NodeIdCluster {
     // Inclusive range of node ids in the cluster.
@@ -557,9 +391,7 @@ impl<'a> From<&'a GBWT> for PathStartSource<'a> {
 mod tests {
     use super::*;
 
-    use std::collections::HashSet;
-
-    use gbz::GBZ;
+    use gbz::support::{self, Orientation};
     use simple_sds::serialize;
 
     #[test]
@@ -570,92 +402,6 @@ mod tests {
             let encoded = encode_sequence(sequence);
             let decoded = decode_sequence(&encoded);
             assert_eq!(decoded, sequence, "Wrong sequence encoding for length {}", i);
-        }
-    }
-
-    fn load_chains(filename: &PathBuf) -> Vec<IntVector> {
-        let file = File::open(&filename);
-        assert!(file.is_ok(), "Failed to open chains file {}", filename.display());
-        let mut file = file.unwrap();
-        let data = Chains::read_data(&mut file);
-        assert!(data.is_ok(), "Failed to read chains from {}", filename.display());
-        data.unwrap()
-    }
-
-    fn check_chains(chains: &Chains, data: &[IntVector]) {
-        assert_eq!(chains.len(), data.len(), "Wrong number of chains");
-        let mut expected_links = 0;
-        for chain in data.iter() {
-            if chain.len() > 1 {
-                expected_links += chain.len() - 1;
-            }
-        }
-        assert_eq!(chains.links(), expected_links, "Wrong number of links");
-
-        // Handles and nodes should be present.
-        for chain in data.iter() {
-            for handle in chain.iter().map(|x| x as usize) {
-                assert!(chains.has_handle(handle), "Missing handle {}", handle);
-                let rev_handle = support::flip_node(handle);
-                assert!(chains.has_handle(rev_handle), "Missing reverse handle {}", rev_handle);
-                let (node_id, _) = support::decode_node(handle);
-                assert!(chains.has_node(node_id), "Missing node {}", node_id);
-            }
-        }
-
-        // Missing handles and nodes should not be present.
-        let max_handle = data.iter().flat_map(|x| x.iter().map(|y| y as usize)).max().unwrap();
-        assert!(!chains.has_handle(max_handle + 2), "Unexpected handle {}", max_handle + 1);
-        let missing_node = support::decode_node(max_handle).0 + 1;
-        assert!(!chains.has_node(missing_node), "Unexpected node {}", missing_node);
-    }
-
-    fn check_region(graph: &GBZ, chains: &Chains, from: usize, to: usize) {
-        // Active handles. We proceed to their successors but not predecessors.
-        let mut active = vec![from, support::flip_node(to)];
-        // Visited node identifiers.
-        let mut visited = HashSet::new();
-        visited.insert(support::decode_node(from).0);
-        visited.insert(support::decode_node(to).0);
-
-        while !active.is_empty() {
-            let curr = active.pop().unwrap();
-            let (node_id, orientation) = support::decode_node(curr);
-            for (next_id, next_o) in graph.successors(node_id, orientation).unwrap() {
-                if visited.contains(&next_id) {
-                    continue;
-                }
-                let fw_handle = support::encode_node(next_id, next_o);
-                let rev_handle = support::flip_node(fw_handle);
-                assert!(!chains.has_node(next_id), "Reached boundary node {} ({}, {}) from region {}..{}", fw_handle, next_id, next_o, from, to);
-                active.push(fw_handle); active.push(rev_handle);
-                visited.insert(next_id);
-            }
-        }
-    }
-
-    #[test]
-    fn chains_empty() {
-        let chains = Chains::new();
-        assert_eq!(chains.len(), 0, "Expected empty chains");
-        assert_eq!(chains.links(), 0, "Expected no links");
-    }
-
-    #[test]
-    fn chains_nonempty() {
-        let chains_file = get_test_data("micb-kir3dl1.chains");
-        let data = load_chains(&chains_file);
-        let chains = Chains::load_from(&chains_file);
-        if let Err(msg) = chains {
-            panic!("Failed to read chains from {}: {}", chains_file.display(), msg);
-        }
-        let chains = chains.unwrap();
-        check_chains(&chains, &data);
-
-        let graph_file = get_test_data("micb-kir3dl1.gbz");
-        let graph: GBZ = serialize::load_from(&graph_file).unwrap();
-        for (from, to) in chains.iter() {
-            check_region(&graph, &chains, from, to);
         }
     }
 


### PR DESCRIPTION
GBZ-base construction will now find top-level chains using `gbz::algorithms::find_chains()` if a chains file is not provided. This takes a few minutes with an HPRC v2.1 graph. The algorithm produces identical chains to those extracted form a distance index or a snarl decomposition, if each component of the graph contains exactly two tips with a directed path between them.

The `query` tool now has option `--handle` for node-based queries with handles (GBWT node identifiers). These handles are often more readily available than node identifiers when debugging issues.