### PR TITLE
Add --extend-snarls option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ After extracting a subgraph, the query determines all top-level snarls that have
 Then it ensures that those snarls are fully in the subgraph.
 These snarls are based on the top-level chains provided or computed during GBZ-base construction.
 
+`--extend-snarls` handles two additional cases that `--snarls` does not:
+
+* **Partial overlap**: the query interval covers only one boundary node of a top-level snarl.
+  The subgraph is extended to fully include such snarls.
+* **Interval inside snarls**: the query interval starts and/or ends inside a top-level snarl, so one or both outer chain boundary nodes do not appear in the initial subgraph.
+  The path is walked backward from the interval start and forward from the interval end to find the nearest chain boundary on each side, and the subgraph is extended to include them. This covers both the case where the interval lies entirely within a single snarl and the case where its endpoints lie in different snarls.
+
+```sh
+query --contig chrM --interval 3000..4000 --extend-snarls graph.db > out.gfa
+```
+
+`--extend-snarls` implies `--snarls` and should be used with care, as some snarls can be very large.
+
 ### Extracting alignments
 
 If you have a GBZ-base for a graph and a GAF-base for reads aligned to the graph, you can extract the reads aligned to the subgraph:

--- a/README.md
+++ b/README.md
@@ -170,18 +170,16 @@ Other queries can also be made snarl-aware:
 query --contig chrM --interval 3000..4000 --snarls graph.db > out.gfa
 ```
 
-After extracting a subgraph, the query determines all top-level snarls that have their boundary nodes in the extracted subgraph.
+After extracting a subgraph, the query determines all top-level snarls that overlap the extracted subgraph.
+A top-level snarl overlaps the subgraph if the subgraph contains a snarl entry point and at least one successor of that entry point.
 Then it ensures that those snarls are fully in the subgraph.
 These snarls are based on the top-level chains provided or computed during GBZ-base construction.
 
 `--extend-snarls` handles two additional cases that `--snarls` does not:
 
-* **Partial overlap**: a top-level snarl has exactly one boundary node in the initial subgraph after the original extraction (query + context + fully covered snarls).
-  The subgraph is extended to fully include such snarls.
-* **Interval inside snarls**: for path and interval queries, the query interval starts and/or ends inside a top-level snarl, so one or both outer chain boundary nodes do not appear in the initial subgraph.
-  The path is walked backward from the interval start and forward from the interval end to find the nearest chain boundary on each side, and the subgraph is extended to include them. This covers both the case where the interval lies entirely within a single snarl and the case where its endpoints lie in different snarls.
-* **Node inside snarls**: for node-based queries, the original queried nodes or their context may touch a top-level snarl even if neither boundary node is initially present.
-  The touched snarl is still recovered, but the extension does not recurse into neighboring snarls.
+* **Boundary-only subgraphs** are not extended on their own. If the subgraph reaches a snarl boundary but does not contain any successor of the corresponding entry point, the subgraph ends just before that snarl.
+* **Subgraph contained in a snarl**: if the extracted subgraph has no visible chain links, GBZ-base does a greedy undirected traversal from the current subgraph until it reaches the first handle whose opposite orientation has a chain link. If that opposite handle is a snarl entry point, the enclosing snarl is extracted. Otherwise the traversal stops, because the subgraph was on a unary path between snarls.
+* **Node-based queries** with `--extend-snarls` are only supported for a single queried node, because extending multiple disconnected seed nodes is ambiguous.
 
 These extensions are applied once to the snarls touched by the original query.
 

--- a/README.md
+++ b/README.md
@@ -176,10 +176,14 @@ These snarls are based on the top-level chains provided or computed during GBZ-b
 
 `--extend-snarls` handles two additional cases that `--snarls` does not:
 
-* **Partial overlap**: the query interval covers only one boundary node of a top-level snarl.
+* **Partial overlap**: a top-level snarl has exactly one boundary node in the initial subgraph after the original extraction (query + context + fully covered snarls).
   The subgraph is extended to fully include such snarls.
-* **Interval inside snarls**: the query interval starts and/or ends inside a top-level snarl, so one or both outer chain boundary nodes do not appear in the initial subgraph.
+* **Interval inside snarls**: for path and interval queries, the query interval starts and/or ends inside a top-level snarl, so one or both outer chain boundary nodes do not appear in the initial subgraph.
   The path is walked backward from the interval start and forward from the interval end to find the nearest chain boundary on each side, and the subgraph is extended to include them. This covers both the case where the interval lies entirely within a single snarl and the case where its endpoints lie in different snarls.
+* **Node inside snarls**: for node-based queries, the original queried nodes or their context may touch a top-level snarl even if neither boundary node is initially present.
+  The touched snarl is still recovered, but the extension does not recurse into neighboring snarls.
+
+These extensions are applied once to the snarls touched by the original query.
 
 ```sh
 query --contig chrM --interval 3000..4000 --extend-snarls graph.db > out.gfa

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -159,7 +159,8 @@ impl Config {
         let context_desc = format!("context length in bp (not for -b; default: {})", Self::DEFAULT_CONTEXT);
         opts.optopt("", "context", &context_desc, "INT");
         opts.optflag("", "snarls", "include nodes in covered top-level snarls");
-        opts.optopt("", "chains", "top-level chains file (for --snarls with a GBZ graph)", "FILE");
+        opts.optflag("", "extend-snarls", "also extend subgraph to cover partially overlapping top-level snarls (implies --snarls)");
+        opts.optopt("", "chains", "top-level chains file (for --snarls/--extend-snarls with a GBZ graph)", "FILE");
         opts.optflag("", "distinct", "output distinct haplotypes with weights");
         opts.optflag("", "reference-only", "output the reference but no other haplotypes");
         opts.optflag("", "cigar", "output CIGAR strings for the haplotypes");
@@ -292,6 +293,7 @@ impl Config {
             None
         };
         let snarls = matches.opt_present("snarls");
+        let extend_snarls = matches.opt_present("extend-snarls");
         let mut output = HaplotypeOutput::All;
         if matches.opt_present("distinct") {
             output = HaplotypeOutput::Distinct;
@@ -325,7 +327,7 @@ impl Config {
             SubgraphQuery::nodes(nodes)
         };
 
-        Ok(query.with_context(context).with_snarls(snarls).with_output(output))
+        Ok(query.with_context(context).with_snarls(snarls).with_extend_snarls(extend_snarls).with_output(output))
     }
 }
 

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -159,7 +159,7 @@ impl Config {
         let context_desc = format!("context length in bp (not for -b; default: {})", Self::DEFAULT_CONTEXT);
         opts.optopt("", "context", &context_desc, "INT");
         opts.optflag("", "snarls", "include nodes in covered top-level snarls");
-        opts.optflag("", "extend-snarls", "also extend subgraph to finish top-level snarls touched by the query (implies --snarls)");
+        opts.optflag("", "extend-snarls", "also extend subgraph to recover overlapping or enclosing top-level snarls (implies --snarls)");
         opts.optopt("", "chains", "top-level chains file (for --snarls/--extend-snarls with a GBZ graph)", "FILE");
         opts.optflag("", "distinct", "output distinct haplotypes with weights");
         opts.optflag("", "reference-only", "output the reference but no other haplotypes");

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -159,7 +159,7 @@ impl Config {
         let context_desc = format!("context length in bp (not for -b; default: {})", Self::DEFAULT_CONTEXT);
         opts.optopt("", "context", &context_desc, "INT");
         opts.optflag("", "snarls", "include nodes in covered top-level snarls");
-        opts.optflag("", "extend-snarls", "also extend subgraph to cover partially overlapping top-level snarls (implies --snarls)");
+        opts.optflag("", "extend-snarls", "also extend subgraph to finish top-level snarls touched by the query (implies --snarls)");
         opts.optopt("", "chains", "top-level chains file (for --snarls/--extend-snarls with a GBZ graph)", "FILE");
         opts.optflag("", "distinct", "output distinct haplotypes with weights");
         opts.optflag("", "reference-only", "output the reference but no other haplotypes");

--- a/src/db.rs
+++ b/src/db.rs
@@ -1556,6 +1556,7 @@ pub struct GraphInterface<'a> {
     get_tag: Statement<'a>,
     get_tags: Statement<'a>,
     get_record: Statement<'a>,
+    get_chain_links: Statement<'a>,
     get_path: Statement<'a>,
     find_path: Statement<'a>,
     paths_for_sample: Statement<'a>,
@@ -1577,6 +1578,10 @@ impl<'a> GraphInterface<'a> {
 
         let get_record = database.connection.prepare(
             "SELECT edges, bwt, sequence, next FROM Nodes WHERE handle = ?1"
+        ).map_err(|x| x.to_string())?;
+
+        let get_chain_links = database.connection.prepare(
+            "SELECT handle, next FROM Nodes WHERE next IS NOT NULL ORDER BY handle"
         ).map_err(|x| x.to_string())?;
 
         let get_path = database.connection.prepare(
@@ -1603,7 +1608,7 @@ impl<'a> GraphInterface<'a> {
 
         Ok(GraphInterface {
             get_tag, get_tags,
-            get_record,
+            get_record, get_chain_links,
             get_path, find_path, paths_for_sample,
             indexed_position,
         })
@@ -1674,6 +1679,15 @@ impl<'a> GraphInterface<'a> {
                 Ok(GBZRecord { handle, edges, bwt, sequence, next })
             }
         ).optional().map_err(|x| x.to_string())
+    }
+
+    /// Returns the stored top-level chain links, ordered by source handle.
+    pub fn chain_links(&mut self) -> Result<Vec<(usize, usize)>, String> {
+        let rows = self.get_chain_links.query_map(
+            (),
+            |row| Ok((row.get(0)?, row.get(1)?))
+        ).map_err(|x| x.to_string())?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(|x| x.to_string())
     }
 
     fn row_to_gbz_path(row: &Row) -> rusqlite::Result<GBZPath> {
@@ -1884,4 +1898,3 @@ fn get_numeric_value(statement: &mut Statement, key: &str) -> Result<usize, Stri
 }
 
 //-----------------------------------------------------------------------------
-

--- a/src/db.rs
+++ b/src/db.rs
@@ -1690,6 +1690,11 @@ impl<'a> GraphInterface<'a> {
         rows.collect::<Result<Vec<_>, _>>().map_err(|x| x.to_string())
     }
 
+    /// Returns `true` if the database stores any top-level chain links.
+    pub fn has_chain_links(&mut self) -> Result<bool, String> {
+        Ok(get_numeric_value(&mut self.get_tag, GBZBase::KEY_CHAIN_LINKS)? > 0)
+    }
+
     fn row_to_gbz_path(row: &Row) -> rusqlite::Result<GBZPath> {
         let handle = row.get(0)?;
         let fw_start = Pos::new(row.get(1)?, row.get(2)?);

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -811,12 +811,10 @@ impl Subgraph {
                 )?;
                 let reference_path = self.path_pos_from_gbz(graph, path_index, query_pos)?;
                 self.around_position(GraphReference::Gbz(graph), reference_path.0.graph_pos(), query.context())?;
-                if query.snarls() || query.extend_snarls() {
-                    self.extract_snarls(GraphReference::Gbz(graph), chains)?;
-                }
                 if query.extend_snarls() {
-                    self.extract_partial_snarls(GraphReference::Gbz(graph), chains)?;
-                    Self::extract_enclosing_snarl_gbz(self, graph, &reference_path.0, 1, chains)?;
+                    self.extend_path_snarls_gbz(graph, chains.unwrap(), &reference_path.0, 1)?;
+                } else if query.snarls() {
+                    self.extract_snarls(GraphReference::Gbz(graph), chains)?;
                 }
                 self.extract_paths(Some(reference_path), query.output())?;
             },
@@ -826,12 +824,10 @@ impl Subgraph {
                 )?;
                 let reference_path = self.path_pos_from_gbz(graph, path_index, query_pos)?;
                 self.around_interval(GraphReference::Gbz(graph), reference_path.0, *len, query.context())?;
-                if query.snarls() || query.extend_snarls() {
-                    self.extract_snarls(GraphReference::Gbz(graph), chains)?;
-                }
                 if query.extend_snarls() {
-                    self.extract_partial_snarls(GraphReference::Gbz(graph), chains)?;
-                    Self::extract_enclosing_snarl_gbz(self, graph, &reference_path.0, *len, chains)?;
+                    self.extend_path_snarls_gbz(graph, chains.unwrap(), &reference_path.0, *len)?;
+                } else if query.snarls() {
+                    self.extract_snarls(GraphReference::Gbz(graph), chains)?;
                 }
                 self.extract_paths(Some(reference_path), query.output())?;
             },
@@ -840,11 +836,11 @@ impl Subgraph {
                     return Err(String::from("Cannot output a reference path in a node-based query"));
                 }
                 self.around_nodes(GraphReference::Gbz(graph), nodes, query.context())?;
-                if query.snarls() || query.extend_snarls() {
-                    self.extract_snarls(GraphReference::Gbz(graph), chains)?;
-                }
                 if query.extend_snarls() {
-                    self.extract_partial_snarls(GraphReference::Gbz(graph), chains)?;
+                    let seed_nodes: BTreeSet<usize> = self.node_iter().collect();
+                    self.extend_node_snarls_gbz(graph, chains.unwrap(), &seed_nodes)?;
+                } else if query.snarls() {
+                    self.extract_snarls(GraphReference::Gbz(graph), chains)?;
                 }
                 self.extract_paths(None, query.output())?;
             },
@@ -919,24 +915,20 @@ impl Subgraph {
             QueryType::PathOffset(query_pos) => {
                 let reference_path = self.path_pos_from_db(graph, query_pos)?;
                 self.around_position(GraphReference::Db(graph), reference_path.0.graph_pos(), query.context())?;
-                if query.snarls() || query.extend_snarls() {
-                    self.extract_snarls(GraphReference::Db(graph), None)?;
-                }
                 if query.extend_snarls() {
-                    self.extract_partial_snarls(GraphReference::Db(graph), None)?;
-                    Self::extract_enclosing_snarl_db(self, graph, query_pos, &reference_path.0, 1)?;
+                    self.extend_path_snarls_db(graph, query_pos, &reference_path.0, 1)?;
+                } else if query.snarls() {
+                    self.extract_snarls(GraphReference::Db(graph), None)?;
                 }
                 self.extract_paths(Some(reference_path), query.output())?;
             },
             QueryType::PathInterval(query_pos, len) => {
                 let reference_path = self.path_pos_from_db(graph, query_pos)?;
                 self.around_interval(GraphReference::Db(graph), reference_path.0, *len, query.context())?;
-                if query.snarls() || query.extend_snarls() {
-                    self.extract_snarls(GraphReference::Db(graph), None)?;
-                }
                 if query.extend_snarls() {
-                    self.extract_partial_snarls(GraphReference::Db(graph), None)?;
-                    Self::extract_enclosing_snarl_db(self, graph, query_pos, &reference_path.0, *len)?;
+                    self.extend_path_snarls_db(graph, query_pos, &reference_path.0, *len)?;
+                } else if query.snarls() {
+                    self.extract_snarls(GraphReference::Db(graph), None)?;
                 }
                 self.extract_paths(Some(reference_path), query.output())?;
             },
@@ -945,11 +937,11 @@ impl Subgraph {
                     return Err(String::from("Cannot output a reference path in a node-based query"));
                 }
                 self.around_nodes(GraphReference::Db(graph), nodes, query.context())?;
-                if query.snarls() || query.extend_snarls() {
-                    self.extract_snarls(GraphReference::Db(graph), None)?;
-                }
                 if query.extend_snarls() {
-                    self.extract_partial_snarls(GraphReference::Db(graph), None)?;
+                    let seed_nodes: BTreeSet<usize> = self.node_iter().collect();
+                    self.extend_node_snarls_db(graph, &seed_nodes)?;
+                } else if query.snarls() {
+                    self.extract_snarls(GraphReference::Db(graph), None)?;
                 }
                 self.extract_paths(None, query.output())?;
             },
@@ -1464,6 +1456,91 @@ impl Subgraph {
         Ok(inserted)
     }
 
+    // Returns true if the given seed nodes contain at least one node in the snarl.
+    fn snarl_overlaps_nodes(
+        graph: &mut GraphReference<'_, '_>,
+        seed_nodes: &BTreeSet<usize>,
+        start: usize,
+        end: usize,
+    ) -> Result<bool, String> {
+        let start_id = support::node_id(start);
+        let end_id = support::node_id(end);
+        if seed_nodes.contains(&start_id) || seed_nodes.contains(&end_id) {
+            return Ok(true);
+        }
+
+        let mut active = vec![start, support::flip_node(end)];
+        let mut visited = HashSet::new();
+        visited.insert(start_id);
+        visited.insert(end_id);
+
+        while let Some(curr) = active.pop() {
+            let record = graph.gbz_record(curr)?;
+            for next in record.successors() {
+                let next_id = support::node_id(next);
+                if !visited.insert(next_id) {
+                    continue;
+                }
+                if seed_nodes.contains(&next_id) {
+                    return Ok(true);
+                }
+                active.push(next);
+                active.push(support::flip_node(next));
+            }
+        }
+
+        Ok(false)
+    }
+
+    // Extends the subgraph to fully cover top-level snarls that overlap the original seed nodes.
+    fn extract_seed_overlapping_snarls_gbz(
+        &mut self,
+        graph: &GBZ,
+        chains: &Chains,
+        seed_nodes: &BTreeSet<usize>,
+    ) -> Result<usize, String> {
+        let mut inserted = 0;
+        for (start, end) in chains.iter().filter(|(start, end)| support::encoded_edge_is_canonical(*start, *end)) {
+            let overlaps = {
+                let mut graph_ref = GraphReference::Gbz(graph);
+                Self::snarl_overlaps_nodes(&mut graph_ref, seed_nodes, start, end)?
+            };
+            if overlaps {
+                inserted += self.between_nodes(GraphReference::Gbz(graph), start, end, None)?;
+            }
+        }
+        Ok(inserted)
+    }
+
+    // Extends path-based queries to the enclosing top-level snarls without recursive propagation.
+    fn extend_path_snarls_gbz(
+        &mut self,
+        graph: &GBZ,
+        chains: &Chains,
+        interval_start: &PathPosition,
+        interval_len: usize,
+    ) -> Result<usize, String> {
+        let mut inserted = 0;
+        inserted += self.extract_snarls(GraphReference::Gbz(graph), Some(chains))?;
+        inserted += self.extract_partial_snarls(GraphReference::Gbz(graph), Some(chains))?;
+        inserted += Self::extract_enclosing_snarl_gbz(self, graph, interval_start, interval_len, Some(chains))?;
+        Ok(inserted)
+    }
+
+    // Extends node-based queries to top-level snarls touched by the original seed nodes.
+    fn extend_node_snarls_gbz(
+        &mut self,
+        graph: &GBZ,
+        chains: &Chains,
+        seed_nodes: &BTreeSet<usize>,
+    ) -> Result<usize, String> {
+        let mut inserted = 0;
+        inserted += self.extract_snarls(GraphReference::Gbz(graph), Some(chains))?;
+        inserted += self.extract_partial_snarls(GraphReference::Gbz(graph), Some(chains))?;
+        inserted += self.extract_seed_overlapping_snarls_gbz(graph, chains, seed_nodes)?;
+        Ok(inserted)
+    }
+
     // Finds and extracts the top-level snarl that fully encloses the given interval (for GBZ graphs).
     // Walks backward from the interval start using GBWT::backward() to find the start chain boundary,
     // then walks forward past the interval to find the end chain boundary.
@@ -1475,7 +1552,7 @@ impl Subgraph {
         interval_start: &PathPosition,
         interval_len: usize,
         chains: Option<&Chains>,
-    ) -> Result<(), String> {
+    ) -> Result<usize, String> {
         // If the interval start is itself a chain boundary, use it directly.
         // Otherwise walk backward to find the nearest chain boundary before it.
         let start_boundary: Option<usize> = if chains.map_or(false, |c| c.has_handle(interval_start.handle())) {
@@ -1512,7 +1589,7 @@ impl Subgraph {
                 node_offset = 0;
                 match record.to_gbwt_record().lf(pos.offset) {
                     Some(next) => pos = next,
-                    None => return Ok(()),
+                        None => return Ok(0),
                 }
             }
 
@@ -1541,10 +1618,10 @@ impl Subgraph {
 
         if let (Some(start), Some(end)) = (start_boundary, end_boundary) {
             if !subgraph.has_handle(start) || !subgraph.has_handle(end) {
-                subgraph.between_nodes(GraphReference::Gbz(graph), start, end, None)?;
+                return subgraph.between_nodes(GraphReference::Gbz(graph), start, end, None);
             }
         }
-        Ok(())
+        Ok(0)
     }
 
     // Returns true if the handle is a top-level chain boundary in a GBZ-base database.
@@ -1573,11 +1650,11 @@ impl Subgraph {
         query_pos: &FullPathName,
         interval_start: &PathPosition,
         interval_len: usize,
-    ) -> Result<(), String> {
+    ) -> Result<usize, String> {
         // Look up the path to get its handle for indexed_position queries.
         let path = match graph.find_path(query_pos)? {
             Some(p) => p,
-            None => return Ok(()),
+            None => return Ok(0),
         };
         let path_handle = path.handle;
 
@@ -1594,7 +1671,7 @@ impl Subgraph {
                 None, // DB case: use GBZRecord::next() stored in the database
             )? {
                 if !subgraph.has_handle(start) || !subgraph.has_handle(end) {
-                    subgraph.between_nodes(GraphReference::Db(graph), start, end, None)?;
+                    return subgraph.between_nodes(GraphReference::Db(graph), start, end, None);
                 }
                 break;
             }
@@ -1603,7 +1680,57 @@ impl Subgraph {
             }
             try_offset = sample_seq - 1;
         }
-        Ok(())
+        Ok(0)
+    }
+
+    // Extends the subgraph to fully cover top-level snarls that overlap the original seed nodes.
+    fn extract_seed_overlapping_snarls_db(
+        &mut self,
+        graph: &mut GraphInterface<'_>,
+        seed_nodes: &BTreeSet<usize>,
+    ) -> Result<usize, String> {
+        let mut inserted = 0;
+        let snarls: Vec<(usize, usize)> = graph.chain_links()?.into_iter()
+            .filter(|(start, end)| support::encoded_edge_is_canonical(*start, *end))
+            .collect();
+        for (start, end) in snarls {
+            let overlaps = {
+                let mut graph_ref = GraphReference::Db(graph);
+                Self::snarl_overlaps_nodes(&mut graph_ref, seed_nodes, start, end)?
+            };
+            if overlaps {
+                inserted += self.between_nodes(GraphReference::Db(graph), start, end, None)?;
+            }
+        }
+        Ok(inserted)
+    }
+
+    // Extends path-based queries to the enclosing top-level snarls without recursive propagation.
+    fn extend_path_snarls_db(
+        &mut self,
+        graph: &mut GraphInterface<'_>,
+        query_pos: &FullPathName,
+        interval_start: &PathPosition,
+        interval_len: usize,
+    ) -> Result<usize, String> {
+        let mut inserted = 0;
+        inserted += self.extract_snarls(GraphReference::Db(graph), None)?;
+        inserted += self.extract_partial_snarls(GraphReference::Db(graph), None)?;
+        inserted += Self::extract_enclosing_snarl_db(self, graph, query_pos, interval_start, interval_len)?;
+        Ok(inserted)
+    }
+
+    // Extends node-based queries to top-level snarls touched by the original seed nodes.
+    fn extend_node_snarls_db(
+        &mut self,
+        graph: &mut GraphInterface<'_>,
+        seed_nodes: &BTreeSet<usize>,
+    ) -> Result<usize, String> {
+        let mut inserted = 0;
+        inserted += self.extract_snarls(GraphReference::Db(graph), None)?;
+        inserted += self.extract_partial_snarls(GraphReference::Db(graph), None)?;
+        inserted += self.extract_seed_overlapping_snarls_db(graph, seed_nodes)?;
+        Ok(inserted)
     }
 
     /// Finds the chain boundary nodes of the top-level snarl that encloses the given path interval.

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -801,7 +801,7 @@ impl Subgraph {
     /// assert_eq!(subgraph.paths(), 3);
     /// ```
     pub fn from_gbz(&mut self, graph: &GBZ, path_index: Option<&PathIndex>, chains: Option<&Chains>, query: &SubgraphQuery) -> Result<(), String> {
-        if query.snarls() && chains.is_none() {
+        if (query.snarls() || query.extend_snarls()) && chains.is_none() {
             return Err(String::from("Top-level chains are required for extracting snarls"));
         }
         match query.query_type() {
@@ -811,8 +811,12 @@ impl Subgraph {
                 )?;
                 let reference_path = self.path_pos_from_gbz(graph, path_index, query_pos)?;
                 self.around_position(GraphReference::Gbz(graph), reference_path.0.graph_pos(), query.context())?;
-                if query.snarls() {
+                if query.snarls() || query.extend_snarls() {
                     self.extract_snarls(GraphReference::Gbz(graph), chains)?;
+                }
+                if query.extend_snarls() {
+                    self.extract_partial_snarls(GraphReference::Gbz(graph), chains)?;
+                    Self::extract_enclosing_snarl_gbz(self, graph, &reference_path.0, 1, chains)?;
                 }
                 self.extract_paths(Some(reference_path), query.output())?;
             },
@@ -822,8 +826,12 @@ impl Subgraph {
                 )?;
                 let reference_path = self.path_pos_from_gbz(graph, path_index, query_pos)?;
                 self.around_interval(GraphReference::Gbz(graph), reference_path.0, *len, query.context())?;
-                if query.snarls() {
+                if query.snarls() || query.extend_snarls() {
                     self.extract_snarls(GraphReference::Gbz(graph), chains)?;
+                }
+                if query.extend_snarls() {
+                    self.extract_partial_snarls(GraphReference::Gbz(graph), chains)?;
+                    Self::extract_enclosing_snarl_gbz(self, graph, &reference_path.0, *len, chains)?;
                 }
                 self.extract_paths(Some(reference_path), query.output())?;
             },
@@ -832,8 +840,11 @@ impl Subgraph {
                     return Err(String::from("Cannot output a reference path in a node-based query"));
                 }
                 self.around_nodes(GraphReference::Gbz(graph), nodes, query.context())?;
-                if query.snarls() {
+                if query.snarls() || query.extend_snarls() {
                     self.extract_snarls(GraphReference::Gbz(graph), chains)?;
+                }
+                if query.extend_snarls() {
+                    self.extract_partial_snarls(GraphReference::Gbz(graph), chains)?;
                 }
                 self.extract_paths(None, query.output())?;
             },
@@ -908,16 +919,24 @@ impl Subgraph {
             QueryType::PathOffset(query_pos) => {
                 let reference_path = self.path_pos_from_db(graph, query_pos)?;
                 self.around_position(GraphReference::Db(graph), reference_path.0.graph_pos(), query.context())?;
-                if query.snarls() {
+                if query.snarls() || query.extend_snarls() {
                     self.extract_snarls(GraphReference::Db(graph), None)?;
+                }
+                if query.extend_snarls() {
+                    self.extract_partial_snarls(GraphReference::Db(graph), None)?;
+                    Self::extract_enclosing_snarl_db(self, graph, query_pos, &reference_path.0, 1)?;
                 }
                 self.extract_paths(Some(reference_path), query.output())?;
             },
             QueryType::PathInterval(query_pos, len) => {
                 let reference_path = self.path_pos_from_db(graph, query_pos)?;
                 self.around_interval(GraphReference::Db(graph), reference_path.0, *len, query.context())?;
-                if query.snarls() {
+                if query.snarls() || query.extend_snarls() {
                     self.extract_snarls(GraphReference::Db(graph), None)?;
+                }
+                if query.extend_snarls() {
+                    self.extract_partial_snarls(GraphReference::Db(graph), None)?;
+                    Self::extract_enclosing_snarl_db(self, graph, query_pos, &reference_path.0, *len)?;
                 }
                 self.extract_paths(Some(reference_path), query.output())?;
             },
@@ -926,8 +945,11 @@ impl Subgraph {
                     return Err(String::from("Cannot output a reference path in a node-based query"));
                 }
                 self.around_nodes(GraphReference::Db(graph), nodes, query.context())?;
-                if query.snarls() {
+                if query.snarls() || query.extend_snarls() {
                     self.extract_snarls(GraphReference::Db(graph), None)?;
+                }
+                if query.extend_snarls() {
+                    self.extract_partial_snarls(GraphReference::Db(graph), None)?;
                 }
                 self.extract_paths(None, query.output())?;
             },
@@ -1382,6 +1404,324 @@ impl Subgraph {
             }
         }
         snarls
+    }
+
+    /// Returns the top-level snarls that partially overlap with the current subgraph.
+    ///
+    /// A snarl partially overlaps if exactly one of its boundary nodes is in the subgraph.
+    /// Each snarl is reported as a pair of handles `(start, end)` of its boundary nodes,
+    /// where `start` is in the subgraph and `end` is not.
+    /// The snarls are returned in the canonical orientation (see [`support::edge_is_canonical`]).
+    ///
+    /// By default, this uses the chain links stored in node records.
+    /// A [`Chains`] object can be provided as an override (required for GBZ graphs).
+    pub fn partially_covered_snarls(&self, chains: Option<&Chains>) -> BTreeSet<(usize, usize)> {
+        let mut snarls: BTreeSet<(usize, usize)> = BTreeSet::new();
+        for (&handle, record) in self.records.iter() {
+            let next = if let Some(chains) = chains {
+                chains.next(handle)
+            } else {
+                record.next()
+            };
+            if next.is_none() {
+                continue;
+            }
+            let next = next.unwrap();
+            if self.has_handle(next) {
+                continue; // Fully covered; handled by covered_snarls / extract_snarls.
+            }
+            if support::encoded_edge_is_canonical(handle, next) {
+                snarls.insert((handle, next));
+            }
+        }
+        snarls
+    }
+
+    /// Extends the subgraph to fully cover top-level snarls that partially overlap with it.
+    ///
+    /// A snarl partially overlaps if exactly one of its boundary nodes is already in the subgraph.
+    /// For each such snarl, all interior nodes (and the missing boundary node) are inserted.
+    /// Returns the number of newly inserted nodes.
+    pub fn extract_partial_snarls(&mut self, graph: GraphReference<'_, '_>, chains: Option<&Chains>) -> Result<usize, String> {
+        let snarls = self.partially_covered_snarls(chains);
+
+        let mut inserted = 0;
+        let mut graph = graph;
+        for (start, end) in snarls {
+            match &mut graph {
+                GraphReference::Gbz(graph) => {
+                    inserted += self.between_nodes(GraphReference::Gbz(graph), start, end, None)?;
+                }
+                GraphReference::Db(graph) => {
+                    inserted += self.between_nodes(GraphReference::Db(graph), start, end, None)?;
+                },
+                GraphReference::None => {
+                    return Err(String::from("No graph reference provided"));
+                }
+            }
+        }
+
+        Ok(inserted)
+    }
+
+    // Finds and extracts the top-level snarl that fully encloses the given interval (for GBZ graphs).
+    // Walks backward from the interval start using GBWT::backward() to find the start chain boundary,
+    // then walks forward past the interval to find the end chain boundary.
+    // This is O(distance to the enclosing snarl boundaries) with no artificial cap.
+    // interval_len should be 1 for point (PathOffset) queries.
+    fn extract_enclosing_snarl_gbz(
+        subgraph: &mut Subgraph,
+        graph: &GBZ,
+        interval_start: &PathPosition,
+        interval_len: usize,
+        chains: Option<&Chains>,
+    ) -> Result<(), String> {
+        // If the interval start is itself a chain boundary, use it directly.
+        // Otherwise walk backward to find the nearest chain boundary before it.
+        let start_boundary: Option<usize> = if chains.map_or(false, |c| c.has_handle(interval_start.handle())) {
+            Some(interval_start.handle())
+        } else {
+            let gbwt: &gbz::GBWT = graph.as_ref();
+            let mut pos = interval_start.gbwt_pos();
+            let mut found: Option<usize> = None;
+            while let Some(prev) = gbwt.backward(pos) {
+                pos = prev;
+                if chains.map_or(false, |c| c.has_handle(pos.node)) {
+                    found = Some(pos.node);
+                    break;
+                }
+            }
+            found
+        };
+
+        // Walk forward past the interval to find the first chain boundary after it.
+        let end_boundary: Option<usize> = {
+            let mut graph_ref = GraphReference::Gbz(graph);
+            let mut pos = interval_start.gbwt_pos();
+            let mut remaining = interval_len;
+            let mut node_offset = interval_start.node_offset();
+
+            // Walk through the interval to reach its last node.
+            loop {
+                let record = graph_ref.gbz_record(pos.node)?;
+                let dist_to_end = record.sequence_len() - node_offset;
+                if remaining <= dist_to_end {
+                    break;
+                }
+                remaining -= dist_to_end;
+                node_offset = 0;
+                match record.to_gbwt_record().lf(pos.offset) {
+                    Some(next) => pos = next,
+                    None => return Ok(()),
+                }
+            }
+
+            // If the last node of the interval is itself a chain boundary, use it directly.
+            // Otherwise continue forward until hitting a chain boundary.
+            if chains.map_or(false, |c| c.has_handle(pos.node)) {
+                Some(pos.node)
+            } else {
+                let mut found: Option<usize> = None;
+                loop {
+                    let record = graph_ref.gbz_record(pos.node)?;
+                    match record.to_gbwt_record().lf(pos.offset) {
+                        Some(next) => {
+                            pos = next;
+                            if chains.map_or(false, |c| c.has_handle(pos.node)) {
+                                found = Some(pos.node);
+                                break;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                found
+            }
+        };
+
+        if let (Some(start), Some(end)) = (start_boundary, end_boundary) {
+            if !subgraph.has_handle(start) || !subgraph.has_handle(end) {
+                subgraph.between_nodes(GraphReference::Gbz(graph), start, end, None)?;
+            }
+        }
+        Ok(())
+    }
+
+    // Same as extract_enclosing_snarl_gbz but for GBZ-base databases (no explicit Chains object;
+    // chain links are read from GBZRecord::next()).
+    fn extract_enclosing_snarl_db(
+        subgraph: &mut Subgraph,
+        graph: &mut GraphInterface<'_>,
+        query_pos: &FullPathName,
+        interval_start: &PathPosition,
+        interval_len: usize,
+    ) -> Result<(), String> {
+        // Look up the path to get its handle for indexed_position queries.
+        let path = match graph.find_path(query_pos)? {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+        let path_handle = path.handle;
+
+        const MAX_SAMPLE_SEARCHES: usize = 64;
+        let mut try_offset = interval_start.seq_offset();
+        for _ in 0..MAX_SAMPLE_SEARCHES {
+            let (sample_seq, sample_pos) = match graph.indexed_position(path_handle, try_offset)? {
+                Some(p) => p,
+                None => break,
+            };
+            if let Some((start, end)) = Self::find_enclosing_snarl_boundaries(
+                &mut GraphReference::Db(graph),
+                sample_seq, sample_pos,
+                interval_start, interval_len,
+                None, // DB case: use GBZRecord::next() stored in the database
+            )? {
+                if !subgraph.has_handle(start) || !subgraph.has_handle(end) {
+                    subgraph.between_nodes(GraphReference::Db(graph), start, end, None)?;
+                }
+                break;
+            }
+            if sample_seq == 0 {
+                break;
+            }
+            try_offset = sample_seq.saturating_sub(1);
+        }
+        Ok(())
+    }
+
+    /// Finds the chain boundary nodes of the top-level snarl that encloses the given path interval.
+    ///
+    /// Used by [`Self::extract_enclosing_snarl_db`] for GBZ-base databases, which do not have a
+    /// GBWT index in memory and cannot use backward walking.
+    /// For GBZ graphs, [`Self::extract_enclosing_snarl_gbz`] uses `GBWT::backward()` directly.
+    ///
+    /// # Arguments
+    ///
+    /// * `graph`: Graph for reading node records (DB variant only).
+    /// * `sample_seq_offset`: Sequence offset of the sampled GBWT position (from the path index).
+    /// * `sample_gbwt_pos`: GBWT position at `sample_seq_offset`.
+    /// * `interval_start`: Starting position of the interval on the reference path.
+    /// * `interval_len`: Length of the interval in bp (use 1 for point queries).
+    /// * `chains`: Always `None` for the DB case; chain links are read from `GBZRecord::next()`.
+    ///
+    /// Returns `Some((start_handle, end_handle))` if both boundary nodes are found, or `None`.
+    ///
+    /// The caller should try progressively earlier samples (by decreasing the query offset) until
+    /// boundaries are found, as the initial sample may itself be inside the enclosing snarl.
+    fn find_enclosing_snarl_boundaries(
+        graph: &mut GraphReference<'_, '_>,
+        sample_seq_offset: usize,
+        sample_gbwt_pos: Pos,
+        interval_start: &PathPosition,
+        interval_len: usize,
+        chains: Option<&Chains>,
+    ) -> Result<Option<(usize, usize)>, String> {
+        // ---- Part 1: Walk forward from the sample to the interval start ----
+        // Record the last chain boundary node seen before the interval start.
+        let start_boundary: Option<usize> = {
+            let mut last_boundary: Option<usize> = None;
+            let mut pos = sample_gbwt_pos;
+            let mut seq_offset = sample_seq_offset;
+            let target = interval_start.seq_offset();
+
+            loop {
+                let record = graph.gbz_record(pos.node)?;
+                let node_len = record.sequence_len();
+
+                // Stop when the current node's range reaches or passes the interval start.
+                // The interval start node is checked separately after the loop.
+                if seq_offset + node_len > target {
+                    break;
+                }
+
+                let is_boundary = if let Some(chains) = chains {
+                    chains.has_handle(pos.node)
+                } else {
+                    record.next().is_some()
+                };
+                if is_boundary {
+                    last_boundary = Some(pos.node);
+                }
+
+                seq_offset += node_len;
+                match record.to_gbwt_record().lf(pos.offset) {
+                    Some(next) => pos = next,
+                    None => break,
+                }
+            }
+
+            // If the interval start is itself a chain boundary, prefer it over the last one seen.
+            let is_boundary = if let Some(chains) = chains {
+                chains.has_handle(interval_start.handle())
+            } else {
+                graph.gbz_record(interval_start.handle())?.next().is_some()
+            };
+            if is_boundary {
+                Some(interval_start.handle())
+            } else {
+                last_boundary
+            }
+        };
+
+        // ---- Part 2: Walk through the interval, then forward to find the end boundary ----
+        let end_boundary: Option<usize> = {
+            let mut pos = interval_start.gbwt_pos();
+            let mut remaining = interval_len;
+            let mut node_offset = interval_start.node_offset();
+
+            // Walk through the interval to reach its last node.
+            loop {
+                let record = graph.gbz_record(pos.node)?;
+                let dist_to_end = record.sequence_len() - node_offset;
+                if remaining <= dist_to_end {
+                    break; // `pos` is now the last node of the interval.
+                }
+                remaining -= dist_to_end;
+                node_offset = 0;
+                match record.to_gbwt_record().lf(pos.offset) {
+                    Some(next) => pos = next,
+                    None => return Ok(None),
+                }
+            }
+
+            // If the last node of the interval is itself a chain boundary, use it directly.
+            // Otherwise continue forward from the interval end to find the first chain boundary.
+            let is_boundary = if let Some(chains) = chains {
+                chains.has_handle(pos.node)
+            } else {
+                graph.gbz_record(pos.node)?.next().is_some()
+            };
+            if is_boundary {
+                Some(pos.node)
+            } else {
+                const MAX_END_STEPS: usize = 100_000;
+                let mut found: Option<usize> = None;
+                for _ in 0..MAX_END_STEPS {
+                    let record = graph.gbz_record(pos.node)?;
+                    match record.to_gbwt_record().lf(pos.offset) {
+                        Some(next) => {
+                            pos = next;
+                            let is_boundary = if let Some(chains) = chains {
+                                chains.has_handle(pos.node)
+                            } else {
+                                graph.gbz_record(pos.node)?.next().is_some()
+                            };
+                            if is_boundary {
+                                found = Some(pos.node);
+                                break;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                found
+            }
+        };
+
+        match (start_boundary, end_boundary) {
+            (Some(start), Some(end)) => Ok(Some((start, end))),
+            _ => Ok(None),
+        }
     }
 }
 

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -1547,6 +1547,24 @@ impl Subgraph {
         Ok(())
     }
 
+    // Returns true if the handle is a top-level chain boundary in a GBZ-base database.
+    //
+    // The chain link may be stored on either orientation of the boundary node.
+    fn db_handle_is_chain_boundary(
+        graph: &mut GraphReference<'_, '_>,
+        handle: usize,
+        record: Option<&GBZRecord>,
+    ) -> Result<bool, String> {
+        if let Some(record) = record {
+            if record.next().is_some() {
+                return Ok(true);
+            }
+        } else if graph.gbz_record(handle)?.next().is_some() {
+            return Ok(true);
+        }
+        Ok(graph.gbz_record(support::flip_node(handle))?.next().is_some())
+    }
+
     // Same as extract_enclosing_snarl_gbz but for GBZ-base databases (no explicit Chains object;
     // chain links are read from GBZRecord::next()).
     fn extract_enclosing_snarl_db(
@@ -1563,9 +1581,8 @@ impl Subgraph {
         };
         let path_handle = path.handle;
 
-        const MAX_SAMPLE_SEARCHES: usize = 64;
         let mut try_offset = interval_start.seq_offset();
-        for _ in 0..MAX_SAMPLE_SEARCHES {
+        loop {
             let (sample_seq, sample_pos) = match graph.indexed_position(path_handle, try_offset)? {
                 Some(p) => p,
                 None => break,
@@ -1584,7 +1601,7 @@ impl Subgraph {
             if sample_seq == 0 {
                 break;
             }
-            try_offset = sample_seq.saturating_sub(1);
+            try_offset = sample_seq - 1;
         }
         Ok(())
     }
@@ -1637,7 +1654,7 @@ impl Subgraph {
                 let is_boundary = if let Some(chains) = chains {
                     chains.has_handle(pos.node)
                 } else {
-                    record.next().is_some()
+                    Self::db_handle_is_chain_boundary(graph, pos.node, Some(&record))?
                 };
                 if is_boundary {
                     last_boundary = Some(pos.node);
@@ -1654,7 +1671,7 @@ impl Subgraph {
             let is_boundary = if let Some(chains) = chains {
                 chains.has_handle(interval_start.handle())
             } else {
-                graph.gbz_record(interval_start.handle())?.next().is_some()
+                Self::db_handle_is_chain_boundary(graph, interval_start.handle(), None)?
             };
             if is_boundary {
                 Some(interval_start.handle())
@@ -1689,14 +1706,13 @@ impl Subgraph {
             let is_boundary = if let Some(chains) = chains {
                 chains.has_handle(pos.node)
             } else {
-                graph.gbz_record(pos.node)?.next().is_some()
+                Self::db_handle_is_chain_boundary(graph, pos.node, None)?
             };
             if is_boundary {
                 Some(pos.node)
             } else {
-                const MAX_END_STEPS: usize = 100_000;
                 let mut found: Option<usize> = None;
-                for _ in 0..MAX_END_STEPS {
+                loop {
                     let record = graph.gbz_record(pos.node)?;
                     match record.to_gbwt_record().lf(pos.offset) {
                         Some(next) => {
@@ -1704,7 +1720,7 @@ impl Subgraph {
                             let is_boundary = if let Some(chains) = chains {
                                 chains.has_handle(pos.node)
                             } else {
-                                graph.gbz_record(pos.node)?.next().is_some()
+                                Self::db_handle_is_chain_boundary(graph, pos.node, None)?
                             };
                             if is_boundary {
                                 found = Some(pos.node);

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -1409,6 +1409,9 @@ impl Subgraph {
     /// By default, this uses the chain links stored in node records.
     /// A [`Chains`] object can be provided as an override (required for GBZ graphs).
     pub fn partially_covered_snarls(&self, chains: Option<&Chains>) -> BTreeSet<(usize, usize)> {
+        if self.weakly_connected_components() != 1 {
+            return BTreeSet::new();
+        }
         let mut snarls: BTreeSet<(usize, usize)> = BTreeSet::new();
         for (&handle, record) in self.records.iter() {
             let Some(next) = self.snarl_entry_successor_in_subgraph(handle, record, chains) else {
@@ -1525,7 +1528,7 @@ impl Subgraph {
             return Ok(chains.links() > 0);
         }
         match graph {
-            GraphReference::Db(db) => Ok(!db.chain_links()?.is_empty()),
+            GraphReference::Db(db) => db.has_chain_links(),
             GraphReference::Gbz(_) => Ok(false),
             GraphReference::None => Err(String::from("No graph reference provided")),
         }
@@ -1589,14 +1592,16 @@ impl Subgraph {
             let opposite_record = graph.gbz_record(opposite)?;
             if let Some(next) = Self::record_next(&opposite_record, chains) {
                 if Self::handle_is_snarl_entry_point(&mut graph, opposite, Some(&opposite_record), chains)? {
+                    let mut inserted = 0;
                     for node_id in collected {
                         if !self.has_node(node_id) {
                             self.add_node_internal(&mut graph, node_id)?;
+                            inserted += 1;
                         }
                     }
                     return match &mut graph {
-                        GraphReference::Gbz(gbz) => self.between_nodes(GraphReference::Gbz(gbz), opposite, next, None),
-                        GraphReference::Db(db) => self.between_nodes(GraphReference::Db(db), opposite, next, None),
+                        GraphReference::Gbz(gbz) => Ok(inserted + self.between_nodes(GraphReference::Gbz(gbz), opposite, next, None)?),
+                        GraphReference::Db(db) => Ok(inserted + self.between_nodes(GraphReference::Db(db), opposite, next, None)?),
                         GraphReference::None => Err(String::from("No graph reference provided")),
                     };
                 }
@@ -1630,7 +1635,9 @@ impl Subgraph {
     ) -> Result<usize, String> {
         let mut inserted = 0;
         inserted += self.extract_snarls(GraphReference::Gbz(graph), Some(chains))?;
-        inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Gbz(graph), Some(chains))?;
+        if !self.has_visible_chain_link(Some(chains)) {
+            inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Gbz(graph), Some(chains))?;
+        }
         Ok(inserted)
     }
 
@@ -1642,7 +1649,9 @@ impl Subgraph {
     ) -> Result<usize, String> {
         let mut inserted = 0;
         inserted += self.extract_snarls(GraphReference::Gbz(graph), Some(chains))?;
-        inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Gbz(graph), Some(chains))?;
+        if !self.has_visible_chain_link(Some(chains)) {
+            inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Gbz(graph), Some(chains))?;
+        }
         Ok(inserted)
     }
 
@@ -1653,7 +1662,9 @@ impl Subgraph {
     ) -> Result<usize, String> {
         let mut inserted = 0;
         inserted += self.extract_snarls(GraphReference::Db(graph), None)?;
-        inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Db(graph), None)?;
+        if !self.has_visible_chain_link(None) {
+            inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Db(graph), None)?;
+        }
         Ok(inserted)
     }
 
@@ -1664,7 +1675,9 @@ impl Subgraph {
     ) -> Result<usize, String> {
         let mut inserted = 0;
         inserted += self.extract_snarls(GraphReference::Db(graph), None)?;
-        inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Db(graph), None)?;
+        if !self.has_visible_chain_link(None) {
+            inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Db(graph), None)?;
+        }
         Ok(inserted)
     }
 }

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -14,6 +14,7 @@ use crate::formats::{self, WalkMetadata, JSONValue};
 
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, BTreeMap, BTreeSet, HashSet};
+use std::collections::VecDeque;
 use std::fmt::Display;
 use std::io::{self, Write};
 use std::iter::FusedIterator;
@@ -709,9 +710,9 @@ impl Subgraph {
     /// let chains_file = utils::get_test_data("example.chains");
     /// let chains: Chains = serialize::load_from(&chains_file).unwrap();
     ///
-    /// // Extract the boundary nodes of a snarl as the initial subgraph.
+    /// // Extract an entry point and one interior node of a snarl as the initial subgraph.
     /// let mut subgraph = Subgraph::new();
-    /// let nodes: BTreeSet<usize> = [14, 17].into_iter().collect();
+    /// let nodes: BTreeSet<usize> = [14, 16].into_iter().collect();
     /// let result = subgraph.around_nodes(GraphReference::Gbz(&graph), &nodes, 0);
     /// assert!(result.is_ok());
     /// assert!(subgraph.node_iter().eq(nodes.iter().copied()));
@@ -812,7 +813,7 @@ impl Subgraph {
                 let reference_path = self.path_pos_from_gbz(graph, path_index, query_pos)?;
                 self.around_position(GraphReference::Gbz(graph), reference_path.0.graph_pos(), query.context())?;
                 if query.extend_snarls() {
-                    self.extend_path_snarls_gbz(graph, chains.unwrap(), &reference_path.0, 1)?;
+                    self.extend_path_snarls_gbz(graph, chains.unwrap())?;
                 } else if query.snarls() {
                     self.extract_snarls(GraphReference::Gbz(graph), chains)?;
                 }
@@ -825,7 +826,7 @@ impl Subgraph {
                 let reference_path = self.path_pos_from_gbz(graph, path_index, query_pos)?;
                 self.around_interval(GraphReference::Gbz(graph), reference_path.0, *len, query.context())?;
                 if query.extend_snarls() {
-                    self.extend_path_snarls_gbz(graph, chains.unwrap(), &reference_path.0, *len)?;
+                    self.extend_path_snarls_gbz(graph, chains.unwrap())?;
                 } else if query.snarls() {
                     self.extract_snarls(GraphReference::Gbz(graph), chains)?;
                 }
@@ -835,10 +836,12 @@ impl Subgraph {
                 if query.output() == HaplotypeOutput::ReferenceOnly {
                     return Err(String::from("Cannot output a reference path in a node-based query"));
                 }
+                if query.extend_snarls() && nodes.len() > 1 {
+                    return Err(String::from("--extend-snarls is only supported for node-based queries with a single node"));
+                }
                 self.around_nodes(GraphReference::Gbz(graph), nodes, query.context())?;
                 if query.extend_snarls() {
-                    let seed_nodes: BTreeSet<usize> = self.node_iter().collect();
-                    self.extend_node_snarls_gbz(graph, chains.unwrap(), &seed_nodes)?;
+                    self.extend_node_snarls_gbz(graph, chains.unwrap())?;
                 } else if query.snarls() {
                     self.extract_snarls(GraphReference::Gbz(graph), chains)?;
                 }
@@ -916,7 +919,7 @@ impl Subgraph {
                 let reference_path = self.path_pos_from_db(graph, query_pos)?;
                 self.around_position(GraphReference::Db(graph), reference_path.0.graph_pos(), query.context())?;
                 if query.extend_snarls() {
-                    self.extend_path_snarls_db(graph, query_pos, &reference_path.0, 1)?;
+                    self.extend_path_snarls_db(graph)?;
                 } else if query.snarls() {
                     self.extract_snarls(GraphReference::Db(graph), None)?;
                 }
@@ -926,7 +929,7 @@ impl Subgraph {
                 let reference_path = self.path_pos_from_db(graph, query_pos)?;
                 self.around_interval(GraphReference::Db(graph), reference_path.0, *len, query.context())?;
                 if query.extend_snarls() {
-                    self.extend_path_snarls_db(graph, query_pos, &reference_path.0, *len)?;
+                    self.extend_path_snarls_db(graph)?;
                 } else if query.snarls() {
                     self.extract_snarls(GraphReference::Db(graph), None)?;
                 }
@@ -936,10 +939,12 @@ impl Subgraph {
                 if query.output() == HaplotypeOutput::ReferenceOnly {
                     return Err(String::from("Cannot output a reference path in a node-based query"));
                 }
+                if query.extend_snarls() && nodes.len() > 1 {
+                    return Err(String::from("--extend-snarls is only supported for node-based queries with a single node"));
+                }
                 self.around_nodes(GraphReference::Db(graph), nodes, query.context())?;
                 if query.extend_snarls() {
-                    let seed_nodes: BTreeSet<usize> = self.node_iter().collect();
-                    self.extend_node_snarls_db(graph, &seed_nodes)?;
+                    self.extend_node_snarls_db(graph)?;
                 } else if query.snarls() {
                     self.extract_snarls(GraphReference::Db(graph), None)?;
                 }
@@ -1367,10 +1372,12 @@ impl Subgraph {
         self.paths.len()
     }
 
-    /// Returns the top-level snarls covered by the current subgraph.
+    /// Returns the top-level snarls overlapping the current subgraph.
     ///
-    /// Each snarl is reported as a pair of handles `(start, end)` of its boundary nodes.
-    /// Here `start` points inside the snarl and `end` points outside the snarl.
+    /// A top-level snarl overlaps the current subgraph if the subgraph contains a snarl entry
+    /// point and at least one successor of that entry point.
+    /// Each snarl is reported as a pair of handles `(start, end)` of its boundary nodes, where
+    /// `start` points inside the snarl and `end` points outside the snarl.
     /// The snarls are returned in the canonical orientation (see [`support::edge_is_canonical`]).
     ///
     /// By default, this uses the chain links stored in node records.
@@ -1379,30 +1386,24 @@ impl Subgraph {
     pub fn covered_snarls(&self, chains: Option<&Chains>) -> BTreeSet<(usize, usize)> {
         let mut snarls: BTreeSet<(usize, usize)> = BTreeSet::new();
         for (&handle, record) in self.records.iter() {
-            let next = if let Some(chains) = chains {
-                chains.next(handle)
-            } else {
-                record.next()
+            let Some(next) = self.snarl_entry_successor_in_subgraph(handle, record, chains) else {
+                continue;
             };
-            if next.is_none() {
+            if !record.successors().any(|successor| self.has_handle(successor)) {
                 continue;
             }
-            let next = next.unwrap();
-            if !self.has_handle(next) {
-                continue;
-            }
-            if support::encoded_edge_is_canonical(handle, next) {
-                snarls.insert((handle, next));
-            }
+            snarls.insert(Self::canonical_snarl(handle, next));
         }
         snarls
     }
 
     /// Returns the top-level snarls that partially overlap with the current subgraph.
     ///
-    /// A snarl partially overlaps if exactly one of its boundary nodes is in the subgraph.
+    /// A top-level snarl partially overlaps the current subgraph if the subgraph contains a snarl
+    /// entry point and at least one successor of that entry point, but does not yet contain the
+    /// successor boundary node of the snarl.
     /// Each snarl is reported as a pair of handles `(start, end)` of its boundary nodes,
-    /// where `start` is in the subgraph and `end` is not.
+    /// in the canonical orientation.
     /// The snarls are returned in the canonical orientation (see [`support::edge_is_canonical`]).
     ///
     /// By default, this uses the chain links stored in node records.
@@ -1410,20 +1411,14 @@ impl Subgraph {
     pub fn partially_covered_snarls(&self, chains: Option<&Chains>) -> BTreeSet<(usize, usize)> {
         let mut snarls: BTreeSet<(usize, usize)> = BTreeSet::new();
         for (&handle, record) in self.records.iter() {
-            let next = if let Some(chains) = chains {
-                chains.next(handle)
-            } else {
-                record.next()
-            };
-            if next.is_none() {
+            let Some(next) = self.snarl_entry_successor_in_subgraph(handle, record, chains) else {
                 continue;
-            }
-            let next = next.unwrap();
+            };
             if self.has_handle(next) {
                 continue; // Fully covered; handled by covered_snarls / extract_snarls.
             }
-            if support::encoded_edge_is_canonical(handle, next) {
-                snarls.insert((handle, next));
+            if record.successors().any(|successor| self.has_handle(successor)) {
+                snarls.insert(Self::canonical_snarl(handle, next));
             }
         }
         snarls
@@ -1431,7 +1426,8 @@ impl Subgraph {
 
     /// Extends the subgraph to fully cover top-level snarls that partially overlap with it.
     ///
-    /// A snarl partially overlaps if exactly one of its boundary nodes is already in the subgraph.
+    /// A snarl partially overlaps if the subgraph contains a snarl entry point and at least one
+    /// successor of that entry point, but does not yet contain the successor boundary node.
     /// For each such snarl, all interior nodes (and the missing boundary node) are inserted.
     /// Returns the number of newly inserted nodes.
     pub fn extract_partial_snarls(&mut self, graph: GraphReference<'_, '_>, chains: Option<&Chains>) -> Result<usize, String> {
@@ -1456,415 +1452,220 @@ impl Subgraph {
         Ok(inserted)
     }
 
-    // Returns true if the given seed nodes contain at least one node in the snarl.
-    fn snarl_overlaps_nodes(
+    fn canonical_snarl(start: usize, end: usize) -> (usize, usize) {
+        if support::encoded_edge_is_canonical(start, end) {
+            (start, end)
+        } else {
+            (support::flip_node(end), support::flip_node(start))
+        }
+    }
+
+    fn record_next(record: &GBZRecord, chains: Option<&Chains>) -> Option<usize> {
+        if let Some(chains) = chains {
+            chains.next(record.handle())
+        } else {
+            record.next()
+        }
+    }
+
+    fn snarl_entry_successor_in_subgraph(
+        &self,
+        _handle: usize,
+        record: &GBZRecord,
+        chains: Option<&Chains>,
+    ) -> Option<usize> {
+        let next = Self::record_next(record, chains)?;
+
+        let mut successors = record.successors();
+        let successor = successors.next()?;
+        if successors.next().is_some() {
+            return Some(next);
+        }
+
+        let predecessor_record = self.record(support::flip_node(successor))?;
+        if predecessor_record.successors().nth(1).is_some() {
+            Some(next)
+        } else {
+            None
+        }
+    }
+
+    fn handle_is_snarl_entry_point(
         graph: &mut GraphReference<'_, '_>,
-        seed_nodes: &BTreeSet<usize>,
-        start: usize,
-        end: usize,
+        handle: usize,
+        record: Option<&GBZRecord>,
+        chains: Option<&Chains>,
     ) -> Result<bool, String> {
-        let start_id = support::node_id(start);
-        let end_id = support::node_id(end);
-        if seed_nodes.contains(&start_id) || seed_nodes.contains(&end_id) {
+        let record_storage;
+        let record = match record {
+            Some(record) => record,
+            None => {
+                record_storage = graph.gbz_record(handle)?;
+                &record_storage
+            }
+        };
+        if Self::record_next(record, chains).is_none() {
+            return Ok(false);
+        }
+
+        let mut successors = record.successors();
+        let Some(successor) = successors.next() else {
+            return Ok(false);
+        };
+        if successors.next().is_some() {
             return Ok(true);
         }
 
-        let mut active = vec![start, support::flip_node(end)];
-        let mut visited = HashSet::new();
-        visited.insert(start_id);
-        visited.insert(end_id);
+        let predecessor_record = graph.gbz_record(support::flip_node(successor))?;
+        Ok(predecessor_record.successors().nth(1).is_some())
+    }
 
-        while let Some(curr) = active.pop() {
-            let record = graph.gbz_record(curr)?;
-            for next in record.successors() {
-                let next_id = support::node_id(next);
-                if !visited.insert(next_id) {
-                    continue;
+    fn has_chain_links(graph: &mut GraphReference<'_, '_>, chains: Option<&Chains>) -> Result<bool, String> {
+        if let Some(chains) = chains {
+            return Ok(chains.links() > 0);
+        }
+        match graph {
+            GraphReference::Db(db) => Ok(!db.chain_links()?.is_empty()),
+            GraphReference::Gbz(_) => Ok(false),
+            GraphReference::None => Err(String::from("No graph reference provided")),
+        }
+    }
+
+    fn has_visible_chain_link(&self, chains: Option<&Chains>) -> bool {
+        self.records.values().any(|record| Self::record_next(record, chains).is_some())
+    }
+
+    fn weakly_connected_components(&self) -> usize {
+        let mut remaining: BTreeSet<usize> = self.node_iter().collect();
+        let mut components = 0;
+
+        while let Some(start) = remaining.first().copied() {
+            components += 1;
+            remaining.remove(&start);
+            let mut stack = vec![start];
+            while let Some(node_id) = stack.pop() {
+                for orientation in [Orientation::Forward, Orientation::Reverse] {
+                    if let Some(successors) = self.successors(node_id, orientation) {
+                        for (next_id, _) in successors {
+                            if remaining.remove(&next_id) {
+                                stack.push(next_id);
+                            }
+                        }
+                    }
                 }
-                if seed_nodes.contains(&next_id) {
-                    return Ok(true);
-                }
-                active.push(next);
-                active.push(support::flip_node(next));
             }
         }
 
-        Ok(false)
+        components
     }
 
-    // Extends the subgraph to fully cover top-level snarls that overlap the original seed nodes.
-    fn extract_seed_overlapping_snarls_gbz(
+    fn extract_enclosing_snarl_by_traversal(
         &mut self,
-        graph: &GBZ,
-        chains: &Chains,
-        seed_nodes: &BTreeSet<usize>,
+        graph: GraphReference<'_, '_>,
+        chains: Option<&Chains>,
     ) -> Result<usize, String> {
-        let mut inserted = 0;
-        for (start, end) in chains.iter().filter(|(start, end)| support::encoded_edge_is_canonical(*start, *end)) {
-            let overlaps = {
-                let mut graph_ref = GraphReference::Gbz(graph);
-                Self::snarl_overlaps_nodes(&mut graph_ref, seed_nodes, start, end)?
-            };
-            if overlaps {
-                inserted += self.between_nodes(GraphReference::Gbz(graph), start, end, None)?;
+        if self.nodes() == 0 || self.weakly_connected_components() != 1 {
+            return Ok(0);
+        }
+
+        let mut graph = graph;
+        if !Self::has_chain_links(&mut graph, chains)? || self.has_visible_chain_link(chains) {
+            return Ok(0);
+        }
+
+        let mut active: VecDeque<usize> = VecDeque::new();
+        let mut visited: HashSet<usize> = HashSet::new();
+        let mut collected: BTreeSet<usize> = BTreeSet::new();
+        for node_id in self.node_iter() {
+            for orientation in [Orientation::Forward, Orientation::Reverse] {
+                let handle = support::encode_node(node_id, orientation);
+                visited.insert(handle);
+                active.push_back(handle);
             }
         }
-        Ok(inserted)
+
+        while let Some(handle) = active.pop_front() {
+            let opposite = support::flip_node(handle);
+            let opposite_record = graph.gbz_record(opposite)?;
+            if let Some(next) = Self::record_next(&opposite_record, chains) {
+                if Self::handle_is_snarl_entry_point(&mut graph, opposite, Some(&opposite_record), chains)? {
+                    for node_id in collected {
+                        if !self.has_node(node_id) {
+                            self.add_node_internal(&mut graph, node_id)?;
+                        }
+                    }
+                    return match &mut graph {
+                        GraphReference::Gbz(gbz) => self.between_nodes(GraphReference::Gbz(gbz), opposite, next, None),
+                        GraphReference::Db(db) => self.between_nodes(GraphReference::Db(db), opposite, next, None),
+                        GraphReference::None => Err(String::from("No graph reference provided")),
+                    };
+                }
+                return Ok(0);
+            }
+
+            let record = graph.gbz_record(handle)?;
+            let node_id = support::node_id(handle);
+            if !self.has_node(node_id) {
+                collected.insert(node_id);
+            }
+            for successor in record.successors() {
+                if visited.insert(successor) {
+                    active.push_back(successor);
+                }
+                let flipped = support::flip_node(successor);
+                if visited.insert(flipped) {
+                    active.push_back(flipped);
+                }
+            }
+        }
+
+        Ok(0)
     }
 
-    // Extends path-based queries to the enclosing top-level snarls without recursive propagation.
+    // Extends path-based queries to the overlapping or enclosing top-level snarls.
     fn extend_path_snarls_gbz(
         &mut self,
         graph: &GBZ,
         chains: &Chains,
-        interval_start: &PathPosition,
-        interval_len: usize,
     ) -> Result<usize, String> {
         let mut inserted = 0;
         inserted += self.extract_snarls(GraphReference::Gbz(graph), Some(chains))?;
-        inserted += self.extract_partial_snarls(GraphReference::Gbz(graph), Some(chains))?;
-        inserted += Self::extract_enclosing_snarl_gbz(self, graph, interval_start, interval_len, Some(chains))?;
+        inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Gbz(graph), Some(chains))?;
         Ok(inserted)
     }
 
-    // Extends node-based queries to top-level snarls touched by the original seed nodes.
+    // Extends node-based queries to overlapping or enclosing top-level snarls.
     fn extend_node_snarls_gbz(
         &mut self,
         graph: &GBZ,
         chains: &Chains,
-        seed_nodes: &BTreeSet<usize>,
     ) -> Result<usize, String> {
         let mut inserted = 0;
         inserted += self.extract_snarls(GraphReference::Gbz(graph), Some(chains))?;
-        inserted += self.extract_partial_snarls(GraphReference::Gbz(graph), Some(chains))?;
-        inserted += self.extract_seed_overlapping_snarls_gbz(graph, chains, seed_nodes)?;
+        inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Gbz(graph), Some(chains))?;
         Ok(inserted)
     }
 
-    // Finds and extracts the top-level snarl that fully encloses the given interval (for GBZ graphs).
-    // Walks backward from the interval start using GBWT::backward() to find the start chain boundary,
-    // then walks forward past the interval to find the end chain boundary.
-    // This is O(distance to the enclosing snarl boundaries) with no artificial cap.
-    // interval_len should be 1 for point (PathOffset) queries.
-    fn extract_enclosing_snarl_gbz(
-        subgraph: &mut Subgraph,
-        graph: &GBZ,
-        interval_start: &PathPosition,
-        interval_len: usize,
-        chains: Option<&Chains>,
-    ) -> Result<usize, String> {
-        // If the interval start is itself a chain boundary, use it directly.
-        // Otherwise walk backward to find the nearest chain boundary before it.
-        let start_boundary: Option<usize> = if chains.map_or(false, |c| c.has_handle(interval_start.handle())) {
-            Some(interval_start.handle())
-        } else {
-            let gbwt: &gbz::GBWT = graph.as_ref();
-            let mut pos = interval_start.gbwt_pos();
-            let mut found: Option<usize> = None;
-            while let Some(prev) = gbwt.backward(pos) {
-                pos = prev;
-                if chains.map_or(false, |c| c.has_handle(pos.node)) {
-                    found = Some(pos.node);
-                    break;
-                }
-            }
-            found
-        };
-
-        // Walk forward past the interval to find the first chain boundary after it.
-        let end_boundary: Option<usize> = {
-            let mut graph_ref = GraphReference::Gbz(graph);
-            let mut pos = interval_start.gbwt_pos();
-            let mut remaining = interval_len;
-            let mut node_offset = interval_start.node_offset();
-
-            // Walk through the interval to reach its last node.
-            loop {
-                let record = graph_ref.gbz_record(pos.node)?;
-                let dist_to_end = record.sequence_len() - node_offset;
-                if remaining <= dist_to_end {
-                    break;
-                }
-                remaining -= dist_to_end;
-                node_offset = 0;
-                match record.to_gbwt_record().lf(pos.offset) {
-                    Some(next) => pos = next,
-                        None => return Ok(0),
-                }
-            }
-
-            // If the last node of the interval is itself a chain boundary, use it directly.
-            // Otherwise continue forward until hitting a chain boundary.
-            if chains.map_or(false, |c| c.has_handle(pos.node)) {
-                Some(pos.node)
-            } else {
-                let mut found: Option<usize> = None;
-                loop {
-                    let record = graph_ref.gbz_record(pos.node)?;
-                    match record.to_gbwt_record().lf(pos.offset) {
-                        Some(next) => {
-                            pos = next;
-                            if chains.map_or(false, |c| c.has_handle(pos.node)) {
-                                found = Some(pos.node);
-                                break;
-                            }
-                        }
-                        None => break,
-                    }
-                }
-                found
-            }
-        };
-
-        if let (Some(start), Some(end)) = (start_boundary, end_boundary) {
-            if !subgraph.has_handle(start) || !subgraph.has_handle(end) {
-                return subgraph.between_nodes(GraphReference::Gbz(graph), start, end, None);
-            }
-        }
-        Ok(0)
-    }
-
-    // Returns true if the handle is a top-level chain boundary in a GBZ-base database.
-    //
-    // The chain link may be stored on either orientation of the boundary node.
-    fn db_handle_is_chain_boundary(
-        graph: &mut GraphReference<'_, '_>,
-        handle: usize,
-        record: Option<&GBZRecord>,
-    ) -> Result<bool, String> {
-        if let Some(record) = record {
-            if record.next().is_some() {
-                return Ok(true);
-            }
-        } else if graph.gbz_record(handle)?.next().is_some() {
-            return Ok(true);
-        }
-        Ok(graph.gbz_record(support::flip_node(handle))?.next().is_some())
-    }
-
-    // Same as extract_enclosing_snarl_gbz but for GBZ-base databases (no explicit Chains object;
-    // chain links are read from GBZRecord::next()).
-    fn extract_enclosing_snarl_db(
-        subgraph: &mut Subgraph,
-        graph: &mut GraphInterface<'_>,
-        query_pos: &FullPathName,
-        interval_start: &PathPosition,
-        interval_len: usize,
-    ) -> Result<usize, String> {
-        // Look up the path to get its handle for indexed_position queries.
-        let path = match graph.find_path(query_pos)? {
-            Some(p) => p,
-            None => return Ok(0),
-        };
-        let path_handle = path.handle;
-
-        let mut try_offset = interval_start.seq_offset();
-        loop {
-            let (sample_seq, sample_pos) = match graph.indexed_position(path_handle, try_offset)? {
-                Some(p) => p,
-                None => break,
-            };
-            if let Some((start, end)) = Self::find_enclosing_snarl_boundaries(
-                &mut GraphReference::Db(graph),
-                sample_seq, sample_pos,
-                interval_start, interval_len,
-                None, // DB case: use GBZRecord::next() stored in the database
-            )? {
-                if !subgraph.has_handle(start) || !subgraph.has_handle(end) {
-                    return subgraph.between_nodes(GraphReference::Db(graph), start, end, None);
-                }
-                break;
-            }
-            if sample_seq == 0 {
-                break;
-            }
-            try_offset = sample_seq - 1;
-        }
-        Ok(0)
-    }
-
-    // Extends the subgraph to fully cover top-level snarls that overlap the original seed nodes.
-    fn extract_seed_overlapping_snarls_db(
-        &mut self,
-        graph: &mut GraphInterface<'_>,
-        seed_nodes: &BTreeSet<usize>,
-    ) -> Result<usize, String> {
-        let mut inserted = 0;
-        let snarls: Vec<(usize, usize)> = graph.chain_links()?.into_iter()
-            .filter(|(start, end)| support::encoded_edge_is_canonical(*start, *end))
-            .collect();
-        for (start, end) in snarls {
-            let overlaps = {
-                let mut graph_ref = GraphReference::Db(graph);
-                Self::snarl_overlaps_nodes(&mut graph_ref, seed_nodes, start, end)?
-            };
-            if overlaps {
-                inserted += self.between_nodes(GraphReference::Db(graph), start, end, None)?;
-            }
-        }
-        Ok(inserted)
-    }
-
-    // Extends path-based queries to the enclosing top-level snarls without recursive propagation.
+    // Extends path-based queries to the overlapping or enclosing top-level snarls.
     fn extend_path_snarls_db(
         &mut self,
         graph: &mut GraphInterface<'_>,
-        query_pos: &FullPathName,
-        interval_start: &PathPosition,
-        interval_len: usize,
     ) -> Result<usize, String> {
         let mut inserted = 0;
         inserted += self.extract_snarls(GraphReference::Db(graph), None)?;
-        inserted += self.extract_partial_snarls(GraphReference::Db(graph), None)?;
-        inserted += Self::extract_enclosing_snarl_db(self, graph, query_pos, interval_start, interval_len)?;
+        inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Db(graph), None)?;
         Ok(inserted)
     }
 
-    // Extends node-based queries to top-level snarls touched by the original seed nodes.
+    // Extends node-based queries to overlapping or enclosing top-level snarls.
     fn extend_node_snarls_db(
         &mut self,
         graph: &mut GraphInterface<'_>,
-        seed_nodes: &BTreeSet<usize>,
     ) -> Result<usize, String> {
         let mut inserted = 0;
         inserted += self.extract_snarls(GraphReference::Db(graph), None)?;
-        inserted += self.extract_partial_snarls(GraphReference::Db(graph), None)?;
-        inserted += self.extract_seed_overlapping_snarls_db(graph, seed_nodes)?;
+        inserted += self.extract_enclosing_snarl_by_traversal(GraphReference::Db(graph), None)?;
         Ok(inserted)
-    }
-
-    /// Finds the chain boundary nodes of the top-level snarl that encloses the given path interval.
-    ///
-    /// Used by [`Self::extract_enclosing_snarl_db`] for GBZ-base databases, which do not have a
-    /// GBWT index in memory and cannot use backward walking.
-    /// For GBZ graphs, [`Self::extract_enclosing_snarl_gbz`] uses `GBWT::backward()` directly.
-    ///
-    /// # Arguments
-    ///
-    /// * `graph`: Graph for reading node records (DB variant only).
-    /// * `sample_seq_offset`: Sequence offset of the sampled GBWT position (from the path index).
-    /// * `sample_gbwt_pos`: GBWT position at `sample_seq_offset`.
-    /// * `interval_start`: Starting position of the interval on the reference path.
-    /// * `interval_len`: Length of the interval in bp (use 1 for point queries).
-    /// * `chains`: Always `None` for the DB case; chain links are read from `GBZRecord::next()`.
-    ///
-    /// Returns `Some((start_handle, end_handle))` if both boundary nodes are found, or `None`.
-    ///
-    /// The caller should try progressively earlier samples (by decreasing the query offset) until
-    /// boundaries are found, as the initial sample may itself be inside the enclosing snarl.
-    fn find_enclosing_snarl_boundaries(
-        graph: &mut GraphReference<'_, '_>,
-        sample_seq_offset: usize,
-        sample_gbwt_pos: Pos,
-        interval_start: &PathPosition,
-        interval_len: usize,
-        chains: Option<&Chains>,
-    ) -> Result<Option<(usize, usize)>, String> {
-        // ---- Part 1: Walk forward from the sample to the interval start ----
-        // Record the last chain boundary node seen before the interval start.
-        let start_boundary: Option<usize> = {
-            let mut last_boundary: Option<usize> = None;
-            let mut pos = sample_gbwt_pos;
-            let mut seq_offset = sample_seq_offset;
-            let target = interval_start.seq_offset();
-
-            loop {
-                let record = graph.gbz_record(pos.node)?;
-                let node_len = record.sequence_len();
-
-                // Stop when the current node's range reaches or passes the interval start.
-                // The interval start node is checked separately after the loop.
-                if seq_offset + node_len > target {
-                    break;
-                }
-
-                let is_boundary = if let Some(chains) = chains {
-                    chains.has_handle(pos.node)
-                } else {
-                    Self::db_handle_is_chain_boundary(graph, pos.node, Some(&record))?
-                };
-                if is_boundary {
-                    last_boundary = Some(pos.node);
-                }
-
-                seq_offset += node_len;
-                match record.to_gbwt_record().lf(pos.offset) {
-                    Some(next) => pos = next,
-                    None => break,
-                }
-            }
-
-            // If the interval start is itself a chain boundary, prefer it over the last one seen.
-            let is_boundary = if let Some(chains) = chains {
-                chains.has_handle(interval_start.handle())
-            } else {
-                Self::db_handle_is_chain_boundary(graph, interval_start.handle(), None)?
-            };
-            if is_boundary {
-                Some(interval_start.handle())
-            } else {
-                last_boundary
-            }
-        };
-
-        // ---- Part 2: Walk through the interval, then forward to find the end boundary ----
-        let end_boundary: Option<usize> = {
-            let mut pos = interval_start.gbwt_pos();
-            let mut remaining = interval_len;
-            let mut node_offset = interval_start.node_offset();
-
-            // Walk through the interval to reach its last node.
-            loop {
-                let record = graph.gbz_record(pos.node)?;
-                let dist_to_end = record.sequence_len() - node_offset;
-                if remaining <= dist_to_end {
-                    break; // `pos` is now the last node of the interval.
-                }
-                remaining -= dist_to_end;
-                node_offset = 0;
-                match record.to_gbwt_record().lf(pos.offset) {
-                    Some(next) => pos = next,
-                    None => return Ok(None),
-                }
-            }
-
-            // If the last node of the interval is itself a chain boundary, use it directly.
-            // Otherwise continue forward from the interval end to find the first chain boundary.
-            let is_boundary = if let Some(chains) = chains {
-                chains.has_handle(pos.node)
-            } else {
-                Self::db_handle_is_chain_boundary(graph, pos.node, None)?
-            };
-            if is_boundary {
-                Some(pos.node)
-            } else {
-                let mut found: Option<usize> = None;
-                loop {
-                    let record = graph.gbz_record(pos.node)?;
-                    match record.to_gbwt_record().lf(pos.offset) {
-                        Some(next) => {
-                            pos = next;
-                            let is_boundary = if let Some(chains) = chains {
-                                chains.has_handle(pos.node)
-                            } else {
-                                Self::db_handle_is_chain_boundary(graph, pos.node, None)?
-                            };
-                            if is_boundary {
-                                found = Some(pos.node);
-                                break;
-                            }
-                        }
-                        None => break,
-                    }
-                }
-                found
-            }
-        };
-
-        match (start_boundary, end_boundary) {
-            (Some(start), Some(end)) => Ok(Some((start, end))),
-            _ => Ok(None),
-        }
     }
 }
 

--- a/src/subgraph/query.rs
+++ b/src/subgraph/query.rs
@@ -77,7 +77,7 @@ pub struct SubgraphQuery {
     // Also extract nodes in covered top-level snarls.
     snarls: bool,
 
-    // Also extend the subgraph to cover top-level snarls that partially overlap with it.
+    // Also extend the subgraph to cover overlapping or enclosing top-level snarls.
     extend_snarls: bool,
 
     // How to output the haplotypes.
@@ -173,19 +173,19 @@ impl SubgraphQuery {
 
     /// Returns an updated query with the given snarl extension flag.
     ///
-    /// When `true`, the subgraph is extended to handle two additional cases:
+    /// When `true`, the subgraph is extended to handle three additional cases:
     ///
-    /// * **Partial overlap**: a top-level snarl has exactly one boundary node in the subgraph
-    ///   after the initial extraction (interval + context + fully covered snarls).
-    ///   The subgraph is extended to fully include such snarls.
-    /// * **Interval inside snarls**: the query interval starts and/or ends inside a top-level snarl,
-    ///   so one or both outer chain boundary nodes do not appear after the initial extraction.
-    ///   The path is walked backward from the interval start and forward from the interval end to
-    ///   find the nearest chain boundary on each side, and the subgraph is extended to include them.
-    ///   This covers both the case where the interval lies entirely within a single snarl and the
-    ///   case where its endpoints lie in different snarls.
+    /// * **Boundary-only subgraph**: reaching a snarl boundary alone does not trigger extension.
+    ///   If the subgraph does not contain any successor of the corresponding snarl entry point,
+    ///   the subgraph ends just before that snarl.
+    /// * **Subgraph contained in a snarl**: if the extracted subgraph contains no visible chain
+    ///   links, GBZ-base performs a greedy undirected traversal until it finds the first handle
+    ///   whose opposite orientation has a chain link. If that opposite handle is a snarl entry
+    ///   point, the enclosing snarl is extracted. Otherwise the traversal stops on a unary path.
+    /// * **Node-based queries**: `--extend-snarls` is only supported for node-based queries with
+    ///   a single queried node, because extending multiple disconnected seed nodes is ambiguous.
     ///
-    /// These extensions are applied once to the snarls touched by the original query.
+    /// These extensions are applied once after extracting fully covered snarls.
     ///
     /// This implies snarl extraction, so [`Self::snarls`] does not need to be set separately.
     /// Note that some snarls can be very large; use this option with care.
@@ -225,19 +225,16 @@ impl SubgraphQuery {
         self.snarls
     }
 
-    /// Returns `true` if the query extends the subgraph to cover snarls touched by the original query.
+    /// Returns `true` if the query extends the subgraph to cover overlapping or enclosing snarls.
     ///
-    /// Two cases are handled:
+    /// The extension changes the default snarl behavior in three ways:
     ///
-    /// * **Partial overlap**: a snarl has exactly one boundary node in the initial subgraph after the
-    ///   original extraction (interval + context + fully covered snarls); the subgraph is extended to include it.
-    /// * **Interval inside snarls**: the interval starts and/or ends inside a snarl, so one or both
-    ///   outer chain boundary nodes are missing; the path is walked backward from the interval start
-    ///   and forward from the interval end to find them, covering both the single-snarl and
-    ///   cross-snarl cases.
-    ///
-    /// For node-based queries, this also covers top-level snarls touched by the original queried
-    /// nodes or their context, even if neither boundary node was initially present.
+    /// * **Boundary-only subgraph**: a boundary node alone is not enough. The subgraph must contain
+    ///   a snarl entry point and at least one successor of that entry point to overlap the snarl.
+    /// * **Subgraph contained in a snarl**: if no visible chain links are present, GBZ-base uses
+    ///   a greedy undirected traversal to find the first enclosing snarl entry point and stops on
+    ///   unary paths between snarls.
+    /// * **Node-based queries**: only single-node seed queries are supported.
     ///
     /// This implies [`Self::snarls`], so fully covered snarls are always extracted first.
     pub fn extend_snarls(&self) -> bool {

--- a/src/subgraph/query.rs
+++ b/src/subgraph/query.rs
@@ -55,6 +55,7 @@ pub(super) enum QueryType {
 /// let query = SubgraphQuery::path_offset(&path_name, 123);
 /// assert_eq!(query.context(), SubgraphQuery::DEFAULT_CONTEXT);
 /// assert_eq!(query.snarls(), SubgraphQuery::DEFAULT_SNARLS);
+/// assert_eq!(query.extend_snarls(), SubgraphQuery::DEFAULT_EXTEND_SNARLS);
 /// assert_eq!(query.output(), SubgraphQuery::DEFAULT_OUTPUT);
 ///
 /// let query = query.with_context(1000);
@@ -62,6 +63,9 @@ pub(super) enum QueryType {
 ///
 /// let query = query.with_snarls(true);
 /// assert!(query.snarls());
+///
+/// let query = query.with_extend_snarls(true);
+/// assert!(query.extend_snarls());
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SubgraphQuery {
@@ -73,6 +77,9 @@ pub struct SubgraphQuery {
     // Also extract nodes in covered top-level snarls.
     snarls: bool,
 
+    // Also extend the subgraph to cover top-level snarls that partially overlap with it.
+    extend_snarls: bool,
+
     // How to output the haplotypes.
     output: HaplotypeOutput,
 }
@@ -83,6 +90,9 @@ impl SubgraphQuery {
 
     /// Default value for the snarl extraction flag.
     pub const DEFAULT_SNARLS: bool = false;
+
+    /// Default value for the partial snarl extension flag.
+    pub const DEFAULT_EXTEND_SNARLS: bool = false;
 
     /// Default value for the haplotype output option.
     pub const DEFAULT_OUTPUT: HaplotypeOutput = HaplotypeOutput::All;
@@ -99,6 +109,7 @@ impl SubgraphQuery {
             query_type: QueryType::PathOffset(path_name),
             context: Self::DEFAULT_CONTEXT,
             snarls: Self::DEFAULT_SNARLS,
+            extend_snarls: Self::DEFAULT_EXTEND_SNARLS,
             output: Self::DEFAULT_OUTPUT,
         }
     }
@@ -115,6 +126,7 @@ impl SubgraphQuery {
             query_type: QueryType::PathInterval(path_name, interval.len()),
             context: Self::DEFAULT_CONTEXT,
             snarls: Self::DEFAULT_SNARLS,
+            extend_snarls: Self::DEFAULT_EXTEND_SNARLS,
             output: Self::DEFAULT_OUTPUT,
         }
     }
@@ -125,6 +137,7 @@ impl SubgraphQuery {
             query_type: QueryType::Nodes(nodes.into_iter().collect()),
             context: Self::DEFAULT_CONTEXT,
             snarls: Self::DEFAULT_SNARLS,
+            extend_snarls: Self::DEFAULT_EXTEND_SNARLS,
             output: Self::DEFAULT_OUTPUT,
         }
     }
@@ -139,6 +152,7 @@ impl SubgraphQuery {
             query_type: QueryType::Between((start, end), limit),
             context: Self::DEFAULT_CONTEXT,
             snarls: Self::DEFAULT_SNARLS,
+            extend_snarls: Self::DEFAULT_EXTEND_SNARLS,
             output: Self::DEFAULT_OUTPUT,
         }
     }
@@ -155,6 +169,28 @@ impl SubgraphQuery {
     /// See [`Self::DEFAULT_SNARLS`] for the default value.
     pub fn with_snarls(self, snarls: bool) -> Self {
         SubgraphQuery { snarls, ..self }
+    }
+
+    /// Returns an updated query with the given snarl extension flag.
+    ///
+    /// When `true`, the subgraph is extended to handle two additional cases:
+    ///
+    /// * **Partial overlap**: a top-level snarl has exactly one boundary node in the subgraph
+    ///   after the initial extraction (interval + context + fully covered snarls).
+    ///   The subgraph is extended to fully include such snarls.
+    /// * **Interval inside snarls**: the query interval starts and/or ends inside a top-level snarl,
+    ///   so one or both outer chain boundary nodes do not appear after the initial extraction.
+    ///   The path is walked backward from the interval start and forward from the interval end to
+    ///   find the nearest chain boundary on each side, and the subgraph is extended to include them.
+    ///   This covers both the case where the interval lies entirely within a single snarl and the
+    ///   case where its endpoints lie in different snarls.
+    ///
+    /// This implies snarl extraction, so [`Self::snarls`] does not need to be set separately.
+    /// Note that some snarls can be very large; use this option with care.
+    ///
+    /// See [`Self::DEFAULT_EXTEND_SNARLS`] for the default value.
+    pub fn with_extend_snarls(self, extend_snarls: bool) -> Self {
+        SubgraphQuery { extend_snarls, ..self }
     }
 
     /// Returns an updated query with the given haplotype output option.
@@ -180,11 +216,27 @@ impl SubgraphQuery {
         self.context
     }
 
-    /// Returns `true` if the query also extracts nodes coverered top-level snarls.
+    /// Returns `true` if the query also extracts nodes in covered top-level snarls.
     ///
-    /// A snarl is covered, if both of its boundary nodes are contained in the query interval or in the context.
+    /// A snarl is covered if both of its boundary nodes are contained in the query interval or in the context.
     pub fn snarls(&self) -> bool {
         self.snarls
+    }
+
+    /// Returns `true` if the query extends the subgraph to cover snarls that overlap with the interval.
+    ///
+    /// Two cases are handled:
+    ///
+    /// * **Partial overlap**: a snarl has exactly one boundary node in the subgraph after the initial
+    ///   extraction (interval + context + fully covered snarls); the subgraph is extended to include it.
+    /// * **Interval inside snarls**: the interval starts and/or ends inside a snarl, so one or both
+    ///   outer chain boundary nodes are missing; the path is walked backward from the interval start
+    ///   and forward from the interval end to find them, covering both the single-snarl and
+    ///   cross-snarl cases.
+    ///
+    /// This implies [`Self::snarls`], so fully covered snarls are always extracted first.
+    pub fn extend_snarls(&self) -> bool {
+        self.extend_snarls
     }
 
     /// Returns the output format for the query.
@@ -195,7 +247,9 @@ impl SubgraphQuery {
 
 impl Display for SubgraphQuery {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let context_str = if self.snarls() {
+        let context_str = if self.extend_snarls() {
+            format!("{} with extended snarls", self.context)
+        } else if self.snarls() {
             format!("{} with snarls", self.context)
         } else {
             format!("{}", self.context)

--- a/src/subgraph/query.rs
+++ b/src/subgraph/query.rs
@@ -185,6 +185,8 @@ impl SubgraphQuery {
     ///   This covers both the case where the interval lies entirely within a single snarl and the
     ///   case where its endpoints lie in different snarls.
     ///
+    /// These extensions are applied once to the snarls touched by the original query.
+    ///
     /// This implies snarl extraction, so [`Self::snarls`] does not need to be set separately.
     /// Note that some snarls can be very large; use this option with care.
     ///
@@ -223,16 +225,19 @@ impl SubgraphQuery {
         self.snarls
     }
 
-    /// Returns `true` if the query extends the subgraph to cover snarls that overlap with the interval.
+    /// Returns `true` if the query extends the subgraph to cover snarls touched by the original query.
     ///
     /// Two cases are handled:
     ///
-    /// * **Partial overlap**: a snarl has exactly one boundary node in the subgraph after the initial
-    ///   extraction (interval + context + fully covered snarls); the subgraph is extended to include it.
+    /// * **Partial overlap**: a snarl has exactly one boundary node in the initial subgraph after the
+    ///   original extraction (interval + context + fully covered snarls); the subgraph is extended to include it.
     /// * **Interval inside snarls**: the interval starts and/or ends inside a snarl, so one or both
     ///   outer chain boundary nodes are missing; the path is walked backward from the interval start
     ///   and forward from the interval end to find them, covering both the single-snarl and
     ///   cross-snarl cases.
+    ///
+    /// For node-based queries, this also covers top-level snarls touched by the original queried
+    /// nodes or their context, even if neither boundary node was initially present.
     ///
     /// This implies [`Self::snarls`], so fully covered snarls are always extracted first.
     pub fn extend_snarls(&self) -> bool {

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -747,23 +747,24 @@ fn partially_covered_snarls() {
 
     let a_first = (support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward));
     let a_second = (support::encode_node(14, Orientation::Forward), support::encode_node(17, Orientation::Forward));
-    let b_first = (support::encode_node(22, Orientation::Reverse), support::encode_node(23, Orientation::Forward));
-    let b_second = (support::encode_node(23, Orientation::Forward), support::encode_node(24, Orientation::Reverse));
+    let _b_first = (support::encode_node(22, Orientation::Reverse), support::encode_node(23, Orientation::Forward));
+    let _b_second = (support::encode_node(23, Orientation::Forward), support::encode_node(24, Orientation::Reverse));
 
     // (nodes_in_subgraph, expected_partial_snarls)
     let queries: Vec<(Vec<usize>, Vec<(usize, usize)>)> = vec![
         (vec![],            vec![]),
-        (vec![11],          vec![a_first]),           // 11→14: 14 not present
-        (vec![14],          vec![a_second]),          // 14→17: 17 not present
-        (vec![11, 14],      vec![a_second]),          // 11→14 fully covered; 14→17 partial
-        (vec![14, 17],      vec![]),                  // 14→17 fully covered
-        (vec![11, 12, 13],  vec![a_first]),           // interior nodes + 11; 14 still missing
+        (vec![11],          vec![]),                  // Boundary only; no successor in the subgraph.
+        (vec![14],          vec![]),                  // Boundary only; no successor in the subgraph.
+        (vec![11, 14],      vec![]),                  // Boundary nodes alone do not overlap the snarl.
+        (vec![14, 17],      vec![]),                  // Same for the second snarl.
+        (vec![11, 12, 13],  vec![a_first]),           // Entry point + interior nodes; successor boundary still missing.
         (vec![11, 14, 17],  vec![]),                  // both snarls fully covered
         (vec![12, 13],      vec![]),                  // interior nodes only, no chain links
-        (vec![22],          vec![b_first]),           // reverse-oriented boundary only
-        (vec![23],          vec![b_second]),          // forward boundary in mixed-orientation chain
-        (vec![22, 23],      vec![b_second]),          // first snarl covered; second still partial
+        (vec![22],          vec![]),                  // Boundary only; no successor in the subgraph.
+        (vec![23],          vec![]),                  // Boundary only; no successor in the subgraph.
+        (vec![22, 23],      vec![]),                  // No entry-point successor overlap.
         (vec![23, 24],      vec![]),                  // second snarl fully covered
+        (vec![11, 14, 16],  vec![a_second]),          // Second snarl overlaps through node 16.
     ];
 
     for (nodes, expected) in queries {
@@ -788,36 +789,81 @@ fn partially_covered_snarls() {
 }
 
 #[test]
-fn db_chain_boundary_check_uses_flipped_handle() {
-    let gbz_file = support::get_test_data("example.gbz");
-    let chains_file = utils::get_test_data("example.chains");
-    let db_file = serialize::temp_file_name("subgraph-db-boundary");
-    let result = GBZBase::create_from_files(&gbz_file, Some(&chains_file), &db_file);
-    assert!(result.is_ok(), "Failed to create database: {}", result.unwrap_err());
-    let mut database = GBZBase::open(&db_file).unwrap();
-    let mut graph = GraphInterface::new(&mut database).unwrap();
+fn snarl_entry_successor_in_subgraph_checks_outdegree_and_indegree() {
+    let handle = support::encode_node(10, Orientation::Forward);
+    let next = support::encode_node(20, Orientation::Forward);
+    let successor = support::encode_node(11, Orientation::Forward);
+    let flipped_successor = support::flip_node(successor);
 
-    let handle = support::encode_node(24, Orientation::Reverse);
-    let record = graph.get_record(handle).unwrap().unwrap();
-    assert!(record.next().is_none(), "Test assumption failed: handle {} unexpectedly has a direct chain link", handle);
-    let mut graph_ref = GraphReference::Db(&mut graph);
-    let is_boundary = Subgraph::db_handle_is_chain_boundary(&mut graph_ref, handle, Some(&record)).unwrap();
-    assert!(is_boundary, "Flipped-handle boundary check failed for handle {}", handle);
+    let mut subgraph = Subgraph::new();
+    let start = unsafe {
+        GBZRecord::from_raw_parts(
+            handle,
+            vec![Pos::new(successor, 0)],
+            Vec::new(),
+            b"A".to_vec(),
+            Some(next),
+        )
+    };
+    let unary_predecessor = unsafe {
+        GBZRecord::from_raw_parts(
+            flipped_successor,
+            vec![Pos::new(support::encode_node(9, Orientation::Reverse), 0)],
+            Vec::new(),
+            b"T".to_vec(),
+            None,
+        )
+    };
+    subgraph.records.insert(handle, start.clone());
+    subgraph.records.insert(flipped_successor, unary_predecessor);
+    assert_eq!(
+        subgraph.snarl_entry_successor_in_subgraph(handle, &start, None),
+        None,
+        "A unary path with successor indegree 1 should not be treated as a snarl entry point"
+    );
 
-    drop(graph_ref);
-    drop(graph);
-    drop(database);
-    fs::remove_file(&db_file).unwrap();
+    let branching_start = unsafe {
+        GBZRecord::from_raw_parts(
+            handle,
+            vec![Pos::new(successor, 0), Pos::new(support::encode_node(12, Orientation::Forward), 0)],
+            Vec::new(),
+            b"A".to_vec(),
+            Some(next),
+        )
+    };
+    assert_eq!(
+        subgraph.snarl_entry_successor_in_subgraph(handle, &branching_start, None),
+        Some(next),
+        "Outdegree > 1 should make the handle a snarl entry point"
+    );
+
+    let indegree_two = unsafe {
+        GBZRecord::from_raw_parts(
+            flipped_successor,
+            vec![
+                Pos::new(support::encode_node(9, Orientation::Reverse), 0),
+                Pos::new(support::encode_node(8, Orientation::Reverse), 0),
+            ],
+            Vec::new(),
+            b"T".to_vec(),
+            None,
+        )
+    };
+    subgraph.records.insert(flipped_successor, indegree_two);
+    assert_eq!(
+        subgraph.snarl_entry_successor_in_subgraph(handle, &start, None),
+        Some(next),
+        "Outdegree 1 with successor indegree > 1 should make the handle a snarl entry point"
+    );
 }
 
 // Returns (queries, (expected_nodes, expected_path_count)) for --extend-snarls tests.
-// Three basic cases:
-//   1. Offset 1 (node 12, interior to snarl 11→14): neither boundary in the initial subgraph.
-//      The enclosing snarl is detected via backward/forward GBWT walking and extracted.
-//   2. Offset 0 (node 11, chain boundary): only one boundary node in the initial subgraph.
-//      The partial snarl is extended to include all interior nodes and the missing boundary.
-//   3. Interval 2..5 (nodes 14→15→17, spanning a full snarl): --extend-snarls gives the same
-//      result as --snarls, because the query already reaches the chain boundary nodes of 14→17.
+// The expectations follow the snarl-entry-point overlap rule:
+//   1. A subgraph overlaps a snarl only if it contains an entry point and at least one successor
+//      of that entry point.
+//   2. Boundary-only subgraphs do not extend into the snarl.
+//   3. If the subgraph contains no visible chain links, it may still be extended to the enclosing
+//      snarl by the greedy undirected traversal.
 fn extend_snarls_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, usize)>) {
     let path_a = FullPathName::generic("A");
     let path_b = FullPathName::generic("B");
@@ -858,14 +904,14 @@ fn extend_snarls_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, us
     ];
     let truth = vec![
         (vec![11, 12, 13, 14], 3),
+        (vec![11], 3),
+        (vec![14, 15, 16, 17], 3),
+        (vec![14], 3),
+        (vec![14, 15, 16, 17], 3),
         (vec![11, 12, 13, 14], 3),
-        (vec![14, 15, 16, 17], 3),
-        (vec![14, 15, 16, 17], 3),
-        (vec![14, 15, 16, 17], 3),
+        (vec![22], 3),
         (vec![11, 12, 13, 14, 15, 16, 17], 3),
         (vec![21, 22, 23], 4),
-        (vec![11, 12, 13, 14, 15, 16, 17], 3),
-        (vec![21], 4),
         (vec![24], 3),
     ];
     (queries, truth)
@@ -885,10 +931,10 @@ fn extend_snarls_node_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize
         SubgraphQuery::nodes([24]).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
     ];
     let truth = vec![
+        (vec![11], 3),
         (vec![11, 12, 13, 14], 3),
-        (vec![11, 12, 13, 14], 3),
-        (vec![21, 22, 23], 4),
-        (vec![23, 24, 25], 3),
+        (vec![22], 3),
+        (vec![24], 3),
     ];
     (queries, truth)
 }
@@ -956,6 +1002,16 @@ fn extend_snarls_from_gbz_nodes() {
 }
 
 #[test]
+fn extend_snarls_from_gbz_nodes_rejects_multiple_seeds() {
+    let (graph, path_index) = internal::load_gbz_and_create_path_index("example.gbz", GBZBase::INDEX_INTERVAL);
+    let chains = internal::load_chains("example.chains");
+    let query = SubgraphQuery::nodes([11, 12]).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All);
+    let mut subgraph = Subgraph::new();
+    let result = subgraph.from_gbz(&graph, Some(&path_index), Some(&chains), &query);
+    assert_eq!(result, Err(String::from("--extend-snarls is only supported for node-based queries with a single node")));
+}
+
+#[test]
 fn extend_snarls_from_db_nodes() {
     let gbz_file = support::get_test_data("example.gbz");
     let gbz_graph: GBZ = serialize::load_from(&gbz_file).unwrap();
@@ -977,6 +1033,26 @@ fn extend_snarls_from_db_nodes() {
         let parent = graph.graph_name().unwrap();
         check_graph_name(&subgraph, true, &parent, &query.to_string());
     }
+
+    drop(graph);
+    drop(database);
+    fs::remove_file(&db_file).unwrap();
+}
+
+#[test]
+fn extend_snarls_from_db_nodes_rejects_multiple_seeds() {
+    let gbz_file = support::get_test_data("example.gbz");
+    let chains_file = utils::get_test_data("example.chains");
+    let db_file = serialize::temp_file_name("subgraph-extend-snarls-nodes-error");
+    let result = GBZBase::create_from_files(&gbz_file, Some(&chains_file), &db_file);
+    assert!(result.is_ok(), "Failed to create database: {}", result.unwrap_err());
+    let mut database = GBZBase::open(&db_file).unwrap();
+    let mut graph = GraphInterface::new(&mut database).unwrap();
+
+    let query = SubgraphQuery::nodes([11, 12]).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All);
+    let mut subgraph = Subgraph::new();
+    let result = subgraph.from_db(&mut graph, &query);
+    assert_eq!(result, Err(String::from("--extend-snarls is only supported for node-based queries with a single node")));
 
     drop(graph);
     drop(database);
@@ -1208,16 +1284,16 @@ fn covered_snarls() {
     // (nodes, snarls)
     let a_first = (support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward));
     let a_second = (support::encode_node(14, Orientation::Forward), support::encode_node(17, Orientation::Forward));
-    let b_first = (support::encode_node(22, Orientation::Reverse), support::encode_node(23, Orientation::Forward));
+    let _b_first = (support::encode_node(22, Orientation::Reverse), support::encode_node(23, Orientation::Forward));
     let b_second = (support::encode_node(23, Orientation::Forward), support::encode_node(24, Orientation::Reverse));
     let queries = vec![
         (vec![], vec![]),
-        (vec![11, 14], vec![a_first]),
-        (vec![11, 14, 17], vec![a_first, a_second]),
-        (vec![12, 13, 14], vec![]),
-        (vec![11, 14, 16], vec![a_first]),
+        (vec![11, 14], vec![]),
+        (vec![11, 14, 17], vec![]),
+        (vec![12, 13, 14], vec![a_first]),
+        (vec![11, 14, 16], vec![a_second]),
         (vec![21, 24], vec![]),
-        (vec![22, 23], vec![b_first]),
+        (vec![22, 23], vec![]),
         (vec![23, 24], vec![b_second]),
     ];
 

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -737,44 +737,124 @@ fn subgraph_from_db() {
     fs::remove_file(&db_file).unwrap();
 }
 
+//-----------------------------------------------------------------------------
+// Tests for --extend-snarls and helper logic it depends on.
+
+#[test]
+fn partially_covered_snarls() {
+    let graph = internal::load_gbz("example.gbz");
+    let chains = internal::load_chains("example.chains");
+
+    let a_first = (support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward));
+    let a_second = (support::encode_node(14, Orientation::Forward), support::encode_node(17, Orientation::Forward));
+    let b_first = (support::encode_node(22, Orientation::Reverse), support::encode_node(23, Orientation::Forward));
+    let b_second = (support::encode_node(23, Orientation::Forward), support::encode_node(24, Orientation::Reverse));
+
+    // (nodes_in_subgraph, expected_partial_snarls)
+    let queries: Vec<(Vec<usize>, Vec<(usize, usize)>)> = vec![
+        (vec![],            vec![]),
+        (vec![11],          vec![a_first]),           // 11→14: 14 not present
+        (vec![14],          vec![a_second]),          // 14→17: 17 not present
+        (vec![11, 14],      vec![a_second]),          // 11→14 fully covered; 14→17 partial
+        (vec![14, 17],      vec![]),                  // 14→17 fully covered
+        (vec![11, 12, 13],  vec![a_first]),           // interior nodes + 11; 14 still missing
+        (vec![11, 14, 17],  vec![]),                  // both snarls fully covered
+        (vec![12, 13],      vec![]),                  // interior nodes only, no chain links
+        (vec![22],          vec![b_first]),           // reverse-oriented boundary only
+        (vec![23],          vec![b_second]),          // forward boundary in mixed-orientation chain
+        (vec![22, 23],      vec![b_second]),          // first snarl covered; second still partial
+        (vec![23, 24],      vec![]),                  // second snarl fully covered
+    ];
+
+    for (nodes, expected) in queries {
+        let mut subgraph = Subgraph::new();
+        let mut name = String::from("(");
+        for (i, &node_id) in nodes.iter().enumerate() {
+            if i > 0 { name.push_str(", "); }
+            name.push_str(&node_id.to_string());
+        }
+        name.push(')');
+        for &node_id in nodes.iter() {
+            subgraph.add_node_from_gbz(&graph, node_id).unwrap_or_else(|e| {
+                panic!("Failed to add node {} in query {}: {}", node_id, name, e);
+            });
+        }
+        let partial = subgraph.partially_covered_snarls(Some(&chains));
+        assert!(
+            partial.iter().eq(expected.iter()),
+            "Wrong partial snarls for {}: found {:?}, expected {:?}", name, partial, expected
+        );
+    }
+}
+
+#[test]
+fn db_chain_boundary_check_uses_flipped_handle() {
+    let gbz_file = support::get_test_data("example.gbz");
+    let chains_file = utils::get_test_data("example.chains");
+    let db_file = serialize::temp_file_name("subgraph-db-boundary");
+    let result = GBZBase::create_from_files(&gbz_file, Some(&chains_file), &db_file);
+    assert!(result.is_ok(), "Failed to create database: {}", result.unwrap_err());
+    let mut database = GBZBase::open(&db_file).unwrap();
+    let mut graph = GraphInterface::new(&mut database).unwrap();
+
+    let handle = support::encode_node(24, Orientation::Reverse);
+    let record = graph.get_record(handle).unwrap().unwrap();
+    assert!(record.next().is_none(), "Test assumption failed: handle {} unexpectedly has a direct chain link", handle);
+    let mut graph_ref = GraphReference::Db(&mut graph);
+    let is_boundary = Subgraph::db_handle_is_chain_boundary(&mut graph_ref, handle, Some(&record)).unwrap();
+    assert!(is_boundary, "Flipped-handle boundary check failed for handle {}", handle);
+
+    drop(graph_ref);
+    drop(graph);
+    drop(database);
+    fs::remove_file(&db_file).unwrap();
+}
+
 // Returns (queries, (expected_nodes, expected_path_count)) for --extend-snarls tests.
-// Three cases:
+// Three basic cases:
 //   1. Offset 1 (node 12, interior to snarl 11→14): neither boundary in the initial subgraph.
-//      The enclosing snarl is detected via backward/forward GBWT walking and fully extracted.
+//      The enclosing snarl is detected via backward/forward GBWT walking and extracted.
 //   2. Offset 0 (node 11, chain boundary): only one boundary node in the initial subgraph.
 //      The partial snarl is extended to include all interior nodes and the missing boundary.
 //   3. Interval 2..5 (nodes 14→15→17, spanning a full snarl): --extend-snarls gives the same
-//      result as --snarls since the snarl 14→17 is fully covered.
+//      result as --snarls, because the query already reaches the chain boundary nodes of 14→17.
 fn extend_snarls_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, usize)>) {
     let path_a = FullPathName::generic("A");
     let path_b = FullPathName::generic("B");
     let queries = vec![
-        // 1. Offset 1 (node 12, interior of snarl 11→14): interval inside snarl, enclosing
-        //    snarl is extracted.
+        // 1. Offset 1 (node 12, interior of snarl 11→14): interval inside snarl, so the
+        //    enclosing snarl is extracted up to its chain boundary nodes 11 and 14.
         SubgraphQuery::path_offset(&path_a, 1).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
         // 2. Offset 0 (node 11, left boundary of snarl 11→14): partial overlap, the snarl
         //    is extended to include all interior nodes and the right boundary.
         SubgraphQuery::path_offset(&path_a, 0).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
-        // 3. Interval 2..5 (nodes 14→15→17, spanning a full snarl): --extend-snarls gives
-        //    the same result as --snarls since the snarl 14→17 is fully covered.
+        // 3. Interval 2..5 (nodes 14→15→17, spanning a full snarl): the query already reaches
+        //    the chain boundary nodes of 14→17, so no neighboring snarl is pulled in.
         SubgraphQuery::path_interval(&path_a, 2..5).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
         // 4. Offset 2 (node 14, the middle chain boundary shared by snarls 11→14 and 14→17):
         //    the interval start/end is exactly on a chain boundary node.
-        //    Only the right snarl (14→17) should be extracted via partial overlap; the left
-        //    snarl (11→14) must NOT be pulled in by the enclosing-snarl walk.
+        //    Only the right snarl (14→17) should be extracted via partial overlap.
         SubgraphQuery::path_offset(&path_a, 2).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
         // 5. Offset 3 (node 15, interior of snarl 14→17) with context 1: context brings in
         //    both chain boundaries (14 and 17), so extract_snarls fills in the snarl interior
-        //    (node 16).  The enclosing-snarl walk finds the boundaries already present and
-        //    does nothing.
+        //    and stops without extending into the previous snarl.
         SubgraphQuery::path_offset(&path_a, 3).with_context(1).with_extend_snarls(true).with_output(HaplotypeOutput::All),
         // 6. Offset 1 (node 12, interior of snarl 11→14) with context 1: context brings in
         //    both chain boundaries (11 and 14), extract_snarls fills the first snarl, and the
-        //    resulting partial overlap on 14→17 cascades to extend into the second snarl.
+        //    resulting partial overlap on 14→17 extends into the second snarl in the same pass.
         SubgraphQuery::path_offset(&path_a, 1).with_context(1).with_extend_snarls(true).with_output(HaplotypeOutput::All),
         // 7. Offset 1 on path B (node 22 on the reference path) sits inside a snarl whose
         //    canonical boundary handles use mixed orientations.
         SubgraphQuery::path_offset(&path_b, 1).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // 8. Interval 1..4 starts inside 11→14 and ends inside 14→17, so the enclosing-snarl
+        //    walk must find chain boundaries on both sides and recover both snarls.
+        SubgraphQuery::path_interval(&path_a, 1..4).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // 9. Offset 0 on path B is at the start of the path, so there is no enclosing boundary
+        //    to the left. The query should not overextend when only one side exists.
+        SubgraphQuery::path_offset(&path_b, 0).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // 10. Offset 2 on path B is at the end of the reference path, so there is no enclosing
+        //     boundary to the right. The query should likewise remain anchored.
+        SubgraphQuery::path_offset(&path_b, 2).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
     ];
     let truth = vec![
         (vec![11, 12, 13, 14], 3),
@@ -784,6 +864,31 @@ fn extend_snarls_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, us
         (vec![14, 15, 16, 17], 3),
         (vec![11, 12, 13, 14, 15, 16, 17], 3),
         (vec![21, 22, 23], 4),
+        (vec![11, 12, 13, 14, 15, 16, 17], 3),
+        (vec![21], 4),
+        (vec![24], 3),
+    ];
+    (queries, truth)
+}
+
+fn extend_snarls_node_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, usize)>) {
+    let queries = vec![
+        // Starting from the left boundary of the first chain extends the touched snarl 11→14.
+        SubgraphQuery::nodes([11]).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // Starting from an interior node in the first snarl should still recover 11→14, even
+        // though neither boundary node is initially present.
+        SubgraphQuery::nodes([12]).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // Starting from a boundary node in chain B extends the touched mixed-orientation snarl.
+        SubgraphQuery::nodes([22]).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // Starting from an interior node in the mixed-orientation chain should recover the same
+        // top-level snarl without propagating further.
+        SubgraphQuery::nodes([24]).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+    ];
+    let truth = vec![
+        (vec![11, 12, 13, 14], 3),
+        (vec![11, 12, 13, 14], 3),
+        (vec![21, 22, 23], 4),
+        (vec![23, 24, 25], 3),
     ];
     (queries, truth)
 }
@@ -817,6 +922,51 @@ fn extend_snarls_from_db() {
     let mut graph = GraphInterface::new(&mut database).unwrap();
 
     let (queries, truth) = extend_snarls_queries_and_truth();
+    for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_db(&mut graph, query);
+        if let Err(err) = result {
+            panic!("Failed to create subgraph for query {}: {}", query, err);
+        }
+        check_subgraph(&gbz_graph, &subgraph, true_nodes, *path_count, &query.to_string());
+        let parent = graph.graph_name().unwrap();
+        check_graph_name(&subgraph, true, &parent, &query.to_string());
+    }
+
+    drop(graph);
+    drop(database);
+    fs::remove_file(&db_file).unwrap();
+}
+
+#[test]
+fn extend_snarls_from_gbz_nodes() {
+    let (graph, path_index) = internal::load_gbz_and_create_path_index("example.gbz", GBZBase::INDEX_INTERVAL);
+    let chains = internal::load_chains("example.chains");
+    let (queries, truth) = extend_snarls_node_queries_and_truth();
+    for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_gbz(&graph, Some(&path_index), Some(&chains), query);
+        if let Err(err) = result {
+            panic!("Failed to create subgraph for query {}: {}", query, err);
+        }
+        check_subgraph(&graph, &subgraph, true_nodes, *path_count, &query.to_string());
+        let parent = GraphName::from_gbz(&graph);
+        check_graph_name(&subgraph, true, &parent, &query.to_string());
+    }
+}
+
+#[test]
+fn extend_snarls_from_db_nodes() {
+    let gbz_file = support::get_test_data("example.gbz");
+    let gbz_graph: GBZ = serialize::load_from(&gbz_file).unwrap();
+    let chains_file = utils::get_test_data("example.chains");
+    let db_file = serialize::temp_file_name("subgraph-extend-snarls-nodes");
+    let result = GBZBase::create_from_files(&gbz_file, Some(&chains_file), &db_file);
+    assert!(result.is_ok(), "Failed to create database: {}", result.unwrap_err());
+    let mut database = GBZBase::open(&db_file).unwrap();
+    let mut graph = GraphInterface::new(&mut database).unwrap();
+
+    let (queries, truth) = extend_snarls_node_queries_and_truth();
     for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
         let mut subgraph = Subgraph::new();
         let result = subgraph.from_db(&mut graph, query);
@@ -1090,76 +1240,6 @@ fn covered_snarls() {
         let covered = subgraph.covered_snarls(Some(&chains));
         assert!(covered.iter().eq(snarls.iter()), "Wrong snarls covered by query {}: found {:?}, expected {:?}", query, covered, snarls);
     }
-}
-
-#[test]
-fn partially_covered_snarls() {
-    let graph = internal::load_gbz("example.gbz");
-    let chains = internal::load_chains("example.chains");
-
-    let a_first = (support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward));
-    let a_second = (support::encode_node(14, Orientation::Forward), support::encode_node(17, Orientation::Forward));
-    let b_first = (support::encode_node(22, Orientation::Reverse), support::encode_node(23, Orientation::Forward));
-    let b_second = (support::encode_node(23, Orientation::Forward), support::encode_node(24, Orientation::Reverse));
-
-    // (nodes_in_subgraph, expected_partial_snarls)
-    let queries: Vec<(Vec<usize>, Vec<(usize, usize)>)> = vec![
-        (vec![],            vec![]),
-        (vec![11],          vec![a_first]),           // 11→14: 14 not present
-        (vec![14],          vec![a_second]),           // 14→17: 17 not present
-        (vec![11, 14],      vec![a_second]),           // 11→14 fully covered; 14→17 partial
-        (vec![14, 17],      vec![]),                   // 14→17 fully covered
-        (vec![11, 12, 13],  vec![a_first]),            // interior nodes + 11; 14 still missing
-        (vec![11, 14, 17],  vec![]),                   // both snarls fully covered
-        (vec![12, 13],      vec![]),                   // interior nodes only, no chain links
-        (vec![22],          vec![b_first]),            // reverse-oriented boundary only
-        (vec![23],          vec![b_second]),           // forward boundary in mixed-orientation chain
-        (vec![22, 23],      vec![b_second]),           // first snarl covered; second still partial
-        (vec![23, 24],      vec![]),                   // second snarl fully covered
-    ];
-
-    for (nodes, expected) in queries {
-        let mut subgraph = Subgraph::new();
-        let mut name = String::from("(");
-        for (i, &node_id) in nodes.iter().enumerate() {
-            if i > 0 { name.push_str(", "); }
-            name.push_str(&node_id.to_string());
-        }
-        name.push(')');
-        for &node_id in nodes.iter() {
-            subgraph.add_node_from_gbz(&graph, node_id).unwrap_or_else(|e| {
-                panic!("Failed to add node {} in query {}: {}", node_id, name, e);
-            });
-        }
-        let partial = subgraph.partially_covered_snarls(Some(&chains));
-        assert!(
-            partial.iter().eq(expected.iter()),
-            "Wrong partial snarls for {}: found {:?}, expected {:?}", name, partial, expected
-        );
-    }
-}
-
-#[test]
-fn db_chain_boundary_check_uses_flipped_handle() {
-    let gbz_file = support::get_test_data("example.gbz");
-    let chains_file = utils::get_test_data("example.chains");
-    let db_file = serialize::temp_file_name("subgraph-db-boundary");
-    let result = GBZBase::create_from_files(&gbz_file, Some(&chains_file), &db_file);
-    assert!(result.is_ok(), "Failed to create database: {}", result.unwrap_err());
-    let mut database = GBZBase::open(&db_file).unwrap();
-    let mut graph = GraphInterface::new(&mut database).unwrap();
-
-    let handle = support::encode_node(24, Orientation::Reverse);
-    let record = graph.get_record(handle).unwrap().unwrap();
-    assert!(record.next().is_none(), "Test assumption failed: handle {} unexpectedly has a direct chain link", handle);
-    let mut graph_ref = GraphReference::Db(&mut graph);
-    let is_boundary = Subgraph::db_handle_is_chain_boundary(&mut graph_ref, handle, Some(&record)).unwrap();
-    assert!(is_boundary, "Flipped-handle boundary check failed for handle {}", handle);
-
-    drop(graph_ref);
-    drop(graph);
-    drop(database);
-    fs::remove_file(&db_file).unwrap();
 }
 
 #[test]

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -747,6 +747,7 @@ fn subgraph_from_db() {
 //      result as --snarls since the snarl 14→17 is fully covered.
 fn extend_snarls_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, usize)>) {
     let path_a = FullPathName::generic("A");
+    let path_b = FullPathName::generic("B");
     let queries = vec![
         // 1. Offset 1 (node 12, interior of snarl 11→14): interval inside snarl, enclosing
         //    snarl is extracted.
@@ -771,6 +772,9 @@ fn extend_snarls_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, us
         //    both chain boundaries (11 and 14), extract_snarls fills the first snarl, and the
         //    resulting partial overlap on 14→17 cascades to extend into the second snarl.
         SubgraphQuery::path_offset(&path_a, 1).with_context(1).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // 7. Offset 1 on path B (node 22 on the reference path) sits inside a snarl whose
+        //    canonical boundary handles use mixed orientations.
+        SubgraphQuery::path_offset(&path_b, 1).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
     ];
     let truth = vec![
         (vec![11, 12, 13, 14], 3),
@@ -779,6 +783,7 @@ fn extend_snarls_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, us
         (vec![14, 15, 16, 17], 3),
         (vec![14, 15, 16, 17], 3),
         (vec![11, 12, 13, 14, 15, 16, 17], 3),
+        (vec![21, 22, 23], 4),
     ];
     (queries, truth)
 }
@@ -1094,6 +1099,8 @@ fn partially_covered_snarls() {
 
     let a_first = (support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward));
     let a_second = (support::encode_node(14, Orientation::Forward), support::encode_node(17, Orientation::Forward));
+    let b_first = (support::encode_node(22, Orientation::Reverse), support::encode_node(23, Orientation::Forward));
+    let b_second = (support::encode_node(23, Orientation::Forward), support::encode_node(24, Orientation::Reverse));
 
     // (nodes_in_subgraph, expected_partial_snarls)
     let queries: Vec<(Vec<usize>, Vec<(usize, usize)>)> = vec![
@@ -1105,6 +1112,10 @@ fn partially_covered_snarls() {
         (vec![11, 12, 13],  vec![a_first]),            // interior nodes + 11; 14 still missing
         (vec![11, 14, 17],  vec![]),                   // both snarls fully covered
         (vec![12, 13],      vec![]),                   // interior nodes only, no chain links
+        (vec![22],          vec![b_first]),            // reverse-oriented boundary only
+        (vec![23],          vec![b_second]),           // forward boundary in mixed-orientation chain
+        (vec![22, 23],      vec![b_second]),           // first snarl covered; second still partial
+        (vec![23, 24],      vec![]),                   // second snarl fully covered
     ];
 
     for (nodes, expected) in queries {
@@ -1126,6 +1137,29 @@ fn partially_covered_snarls() {
             "Wrong partial snarls for {}: found {:?}, expected {:?}", name, partial, expected
         );
     }
+}
+
+#[test]
+fn db_chain_boundary_check_uses_flipped_handle() {
+    let gbz_file = support::get_test_data("example.gbz");
+    let chains_file = utils::get_test_data("example.chains");
+    let db_file = serialize::temp_file_name("subgraph-db-boundary");
+    let result = GBZBase::create_from_files(&gbz_file, Some(&chains_file), &db_file);
+    assert!(result.is_ok(), "Failed to create database: {}", result.unwrap_err());
+    let mut database = GBZBase::open(&db_file).unwrap();
+    let mut graph = GraphInterface::new(&mut database).unwrap();
+
+    let handle = support::encode_node(24, Orientation::Reverse);
+    let record = graph.get_record(handle).unwrap().unwrap();
+    assert!(record.next().is_none(), "Test assumption failed: handle {} unexpectedly has a direct chain link", handle);
+    let mut graph_ref = GraphReference::Db(&mut graph);
+    let is_boundary = Subgraph::db_handle_is_chain_boundary(&mut graph_ref, handle, Some(&record)).unwrap();
+    assert!(is_boundary, "Flipped-handle boundary check failed for handle {}", handle);
+
+    drop(graph_ref);
+    drop(graph);
+    drop(database);
+    fs::remove_file(&db_file).unwrap();
 }
 
 #[test]

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -746,7 +746,7 @@ fn partially_covered_snarls() {
     let chains = internal::load_chains("example.chains");
 
     let a_first = (support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward));
-    let a_second = (support::encode_node(14, Orientation::Forward), support::encode_node(17, Orientation::Forward));
+    let _a_second = (support::encode_node(14, Orientation::Forward), support::encode_node(17, Orientation::Forward));
     let _b_first = (support::encode_node(22, Orientation::Reverse), support::encode_node(23, Orientation::Forward));
     let _b_second = (support::encode_node(23, Orientation::Forward), support::encode_node(24, Orientation::Reverse));
 
@@ -764,7 +764,7 @@ fn partially_covered_snarls() {
         (vec![23],          vec![]),                  // Boundary only; no successor in the subgraph.
         (vec![22, 23],      vec![]),                  // No entry-point successor overlap.
         (vec![23, 24],      vec![]),                  // second snarl fully covered
-        (vec![11, 14, 16],  vec![a_second]),          // Second snarl overlaps through node 16.
+        (vec![11, 14, 16],  vec![]),                  // Multiple components are rejected.
     ];
 
     for (nodes, expected) in queries {
@@ -786,6 +786,20 @@ fn partially_covered_snarls() {
             "Wrong partial snarls for {}: found {:?}, expected {:?}", name, partial, expected
         );
     }
+}
+
+#[test]
+fn partially_covered_snarls_requires_single_component() {
+    let graph = internal::load_gbz("example.gbz");
+    let chains = internal::load_chains("example.chains");
+
+    let mut subgraph = Subgraph::new();
+    for node_id in [11, 12, 13, 23, 24] {
+        subgraph.add_node_from_gbz(&graph, node_id).unwrap();
+    }
+
+    let partial = subgraph.partially_covered_snarls(Some(&chains));
+    assert!(partial.is_empty(), "Expected no partially covered snarls for a multi-component subgraph, found {:?}", partial);
 }
 
 #[test]
@@ -855,6 +869,19 @@ fn snarl_entry_successor_in_subgraph_checks_outdegree_and_indegree() {
         Some(next),
         "Outdegree 1 with successor indegree > 1 should make the handle a snarl entry point"
     );
+}
+
+#[test]
+fn enclosing_snarl_traversal_counts_collected_nodes() {
+    let graph = internal::load_gbz("example.gbz");
+    let chains = internal::load_chains("example.chains");
+
+    let mut subgraph = Subgraph::new();
+    subgraph.around_nodes(GraphReference::Gbz(&graph), &[12].into_iter().collect(), 0).unwrap();
+
+    let inserted = subgraph.extract_enclosing_snarl_by_traversal(GraphReference::Gbz(&graph), Some(&chains)).unwrap();
+    assert_eq!(inserted, 3, "Expected the traversal to count collected unary-path nodes as inserted");
+    assert!(subgraph.node_iter().eq([11, 12, 13, 14].into_iter()), "Traversal failed to recover the enclosing snarl");
 }
 
 // Returns (queries, (expected_nodes, expected_path_count)) for --extend-snarls tests.

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -737,6 +737,97 @@ fn subgraph_from_db() {
     fs::remove_file(&db_file).unwrap();
 }
 
+// Returns (queries, (expected_nodes, expected_path_count)) for --extend-snarls tests.
+// Three cases:
+//   1. Offset 1 (node 12, interior to snarl 11→14): neither boundary in the initial subgraph.
+//      The enclosing snarl is detected via backward/forward GBWT walking and fully extracted.
+//   2. Offset 0 (node 11, chain boundary): only one boundary node in the initial subgraph.
+//      The partial snarl is extended to include all interior nodes and the missing boundary.
+//   3. Interval 2..5 (nodes 14→15→17, spanning a full snarl): --extend-snarls gives the same
+//      result as --snarls since the snarl 14→17 is fully covered.
+fn extend_snarls_queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, usize)>) {
+    let path_a = FullPathName::generic("A");
+    let queries = vec![
+        // 1. Offset 1 (node 12, interior of snarl 11→14): interval inside snarl, enclosing
+        //    snarl is extracted.
+        SubgraphQuery::path_offset(&path_a, 1).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // 2. Offset 0 (node 11, left boundary of snarl 11→14): partial overlap, the snarl
+        //    is extended to include all interior nodes and the right boundary.
+        SubgraphQuery::path_offset(&path_a, 0).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // 3. Interval 2..5 (nodes 14→15→17, spanning a full snarl): --extend-snarls gives
+        //    the same result as --snarls since the snarl 14→17 is fully covered.
+        SubgraphQuery::path_interval(&path_a, 2..5).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // 4. Offset 2 (node 14, the middle chain boundary shared by snarls 11→14 and 14→17):
+        //    the interval start/end is exactly on a chain boundary node.
+        //    Only the right snarl (14→17) should be extracted via partial overlap; the left
+        //    snarl (11→14) must NOT be pulled in by the enclosing-snarl walk.
+        SubgraphQuery::path_offset(&path_a, 2).with_context(0).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // 5. Offset 3 (node 15, interior of snarl 14→17) with context 1: context brings in
+        //    both chain boundaries (14 and 17), so extract_snarls fills in the snarl interior
+        //    (node 16).  The enclosing-snarl walk finds the boundaries already present and
+        //    does nothing.
+        SubgraphQuery::path_offset(&path_a, 3).with_context(1).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+        // 6. Offset 1 (node 12, interior of snarl 11→14) with context 1: context brings in
+        //    both chain boundaries (11 and 14), extract_snarls fills the first snarl, and the
+        //    resulting partial overlap on 14→17 cascades to extend into the second snarl.
+        SubgraphQuery::path_offset(&path_a, 1).with_context(1).with_extend_snarls(true).with_output(HaplotypeOutput::All),
+    ];
+    let truth = vec![
+        (vec![11, 12, 13, 14], 3),
+        (vec![11, 12, 13, 14], 3),
+        (vec![14, 15, 16, 17], 3),
+        (vec![14, 15, 16, 17], 3),
+        (vec![14, 15, 16, 17], 3),
+        (vec![11, 12, 13, 14, 15, 16, 17], 3),
+    ];
+    (queries, truth)
+}
+
+#[test]
+fn extend_snarls_from_gbz() {
+    let (graph, path_index) = internal::load_gbz_and_create_path_index("example.gbz", GBZBase::INDEX_INTERVAL);
+    let chains = internal::load_chains("example.chains");
+    let (queries, truth) = extend_snarls_queries_and_truth();
+    for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_gbz(&graph, Some(&path_index), Some(&chains), query);
+        if let Err(err) = result {
+            panic!("Failed to create subgraph for query {}: {}", query, err);
+        }
+        check_subgraph(&graph, &subgraph, true_nodes, *path_count, &query.to_string());
+        let parent = GraphName::from_gbz(&graph);
+        check_graph_name(&subgraph, true, &parent, &query.to_string());
+    }
+}
+
+#[test]
+fn extend_snarls_from_db() {
+    let gbz_file = support::get_test_data("example.gbz");
+    let gbz_graph: GBZ = serialize::load_from(&gbz_file).unwrap();
+    let chains_file = utils::get_test_data("example.chains");
+    let db_file = serialize::temp_file_name("subgraph-extend-snarls");
+    let result = GBZBase::create_from_files(&gbz_file, Some(&chains_file), &db_file);
+    assert!(result.is_ok(), "Failed to create database: {}", result.unwrap_err());
+    let mut database = GBZBase::open(&db_file).unwrap();
+    let mut graph = GraphInterface::new(&mut database).unwrap();
+
+    let (queries, truth) = extend_snarls_queries_and_truth();
+    for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_db(&mut graph, query);
+        if let Err(err) = result {
+            panic!("Failed to create subgraph for query {}: {}", query, err);
+        }
+        check_subgraph(&gbz_graph, &subgraph, true_nodes, *path_count, &query.to_string());
+        let parent = graph.graph_name().unwrap();
+        check_graph_name(&subgraph, true, &parent, &query.to_string());
+    }
+
+    drop(graph);
+    drop(database);
+    fs::remove_file(&db_file).unwrap();
+}
+
 #[test]
 fn manual_gbz_queries() {
     let (graph, path_index) = internal::load_gbz_and_create_path_index("example.gbz", GBZBase::INDEX_INTERVAL);
@@ -993,6 +1084,47 @@ fn covered_snarls() {
         }
         let covered = subgraph.covered_snarls(Some(&chains));
         assert!(covered.iter().eq(snarls.iter()), "Wrong snarls covered by query {}: found {:?}, expected {:?}", query, covered, snarls);
+    }
+}
+
+#[test]
+fn partially_covered_snarls() {
+    let graph = internal::load_gbz("example.gbz");
+    let chains = internal::load_chains("example.chains");
+
+    let a_first = (support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward));
+    let a_second = (support::encode_node(14, Orientation::Forward), support::encode_node(17, Orientation::Forward));
+
+    // (nodes_in_subgraph, expected_partial_snarls)
+    let queries: Vec<(Vec<usize>, Vec<(usize, usize)>)> = vec![
+        (vec![],            vec![]),
+        (vec![11],          vec![a_first]),           // 11→14: 14 not present
+        (vec![14],          vec![a_second]),           // 14→17: 17 not present
+        (vec![11, 14],      vec![a_second]),           // 11→14 fully covered; 14→17 partial
+        (vec![14, 17],      vec![]),                   // 14→17 fully covered
+        (vec![11, 12, 13],  vec![a_first]),            // interior nodes + 11; 14 still missing
+        (vec![11, 14, 17],  vec![]),                   // both snarls fully covered
+        (vec![12, 13],      vec![]),                   // interior nodes only, no chain links
+    ];
+
+    for (nodes, expected) in queries {
+        let mut subgraph = Subgraph::new();
+        let mut name = String::from("(");
+        for (i, &node_id) in nodes.iter().enumerate() {
+            if i > 0 { name.push_str(", "); }
+            name.push_str(&node_id.to_string());
+        }
+        name.push(')');
+        for &node_id in nodes.iter() {
+            subgraph.add_node_from_gbz(&graph, node_id).unwrap_or_else(|e| {
+                panic!("Failed to add node {} in query {}: {}", node_id, name, e);
+            });
+        }
+        let partial = subgraph.partially_covered_snarls(Some(&chains));
+        assert!(
+            partial.iter().eq(expected.iter()),
+            "Wrong partial snarls for {}: found {:?}, expected {:?}", name, partial, expected
+        );
     }
 }
 


### PR DESCRIPTION
This PR adds `--extend-snarls` to the query tool and a corresponding `with_extend_snarls()` builder on `SubgraphQuery`.

After the standard subgraph extraction (query + context + fully covered snarls), `--extend-snarls` handles additional cases where the original query touches a top-level snarl but the initial subgraph does not yet include the full snarl.

For path and interval queries, two cases are handled:

1. **Partial overlap**: a top-level snarl has exactly one boundary node in the initial subgraph. The subgraph is extended to fully include that snarl. This is implemented by `extract_partial_snarls()`.

2. **Interval inside snarls**: the query interval starts and/or ends inside a top-level snarl, so one or both outer chain boundary nodes are absent from the initial subgraph. The implementation walks backward from the interval start and forward from the interval end to find the nearest chain boundary on each side, then calls `between_nodes()` to fill in the enclosing snarl. This covers both the case where the interval lies entirely within a single snarl and the case where its endpoints lie in different snarls.

For node-based queries, `--extend-snarls` also recovers a top-level snarl touched by the original queried nodes or their context even if neither snarl boundary node is initially present. This is done in a single non-recursive pass and does not propagate into neighboring snarls.

Two backends are provided for the enclosing-snarl path/interval logic:

- `extract_enclosing_snarl_gbz()` for GBZ graphs: uses `GBWT::backward()` via the existing `AsRef<GBWT>` impl on `GBZ` for an O(distance) backward walk with no artificial cap.

- `extract_enclosing_snarl_db()` together with `find_enclosing_snarl_boundaries()` for GBZ-base databases: because the GBWT index is not in memory, the backward direction is reconstructed by scanning forward from indexed path positions to find the last chain boundary before the interval start.

`--extend-snarls` implies `--snarls`, so fully covered snarls are always extracted first. The extension is applied once to the snarls touched by the original query, rather than recursively propagating through neighboring snarls. It should still be used with care, since some snarls can be very large.
