### PR TITLE
Query improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ All other paths will be listed as unknown haplotypes.
   Context length can be specified using suffixes such as `k` or `M`.
 * `--distinct`: Collapse identical paths in the subgraph and report the number of copies using `WT:i` tags.
 * `--reference-only`: Output the query path but no unknown haplotypes.
+* `--no-haplotypes`: Do not include haplotype paths in the output.
 * `--cigar`: Output CIGAR strings relative to the query path as `CG:Z` tags.
 * `--format json`: Extract the subgraph in JSON format instead of GFA.
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ All other paths will be listed as unknown haplotypes.
 ### Other options
 
 * `--handle N`: Node-based query using handles (GBWT node identifiers) encoded as `2 * node_id + is_reverse`.
+* `--limit N`: Abort the query if subgraph size exceeds `N` nodes.
+  The limit can be specified using suffixes such as `k` or `M`.
 * `--context N`: Extract `N` bp context around the query position (default: 100).
   Context length can be specified using suffixes such as `k` or `M`.
 * `--haplotypes X`: Haplotype output selection:
@@ -169,9 +171,7 @@ If no orientation is provided  (e.g. `12345+` or `12401-`), the boundary nodes a
 The query extracts all nodes and snarls in the chain between (and including) the boundary nodes but no greedy context.
 
 If the boundary nodes are not in the same chain or they are given in the wrong order, the outcome is unpredictable.
-To avoid extracting most of the chromosome, a safety limit for the number of nodes may be given with `--limit N`.
-The limit can be specified using suffixes such as `k` or `M`.
-If the limit is exceeded, the query will fail.
+A safety limit (`--limit`) can be useful for dealing with such situations.
 
 ### Extracting snarls covered by a query
 
@@ -191,6 +191,8 @@ The extended subgraph can be much larger than the original one, if:
 * The reference sample contains a large deletion in the subgraph.
 * Context length (`--context`) is non-zero and there is a large deletion in any sample within the context.
 
+A safety limit (`--limit`) can be used to deal with such situations.
+
 ### Extracting snarls overlapping with a query
 
 We can also extend the subgraph with all overlapping snarls:
@@ -206,6 +208,7 @@ If there are no chain links in the subgraph, the query instead tries to find a s
 Option `--extend-snarls` requires that the subgraph is weakly connected.
 It does not work with node-based queries with multiple nodes.
 If the graph contains large snarls, the extended subgraph can be much larger than the original one.
+A safety limit (`--limit`) can be useful here as well.
 
 ### Extracting alignments
 

--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ All other paths will be listed as unknown haplotypes.
 * `--handle N`: Node-based query using handles (GBWT node identifiers) encoded as `2 * node_id + is_reverse`.
 * `--context N`: Extract `N` bp context around the query position (default: 100).
   Context length can be specified using suffixes such as `k` or `M`.
-* `--distinct`: Collapse identical paths in the subgraph and report the number of copies using `WT:i` tags.
-* `--reference-only`: Output the query path but no unknown haplotypes.
-* `--no-haplotypes`: Do not include haplotype paths in the output.
+* `--haplotypes X`: Haplotype output selection:
+  * `all`: Output all haplotypes paths (default).
+  * `distinct`: Collapse identical paths in the subgraph and report the number of copies using `WT:i` tags.
+  * `reference-only`: Output the query path but no unknown haplotypes.
+  * `none`: Do not include haplotype paths in the output.
 * `--cigar`: Output CIGAR strings relative to the query path as `CG:Z` tags.
 * `--format json`: Extract the subgraph in JSON format instead of GFA.
 
@@ -217,6 +219,14 @@ gbz-base query --sample GRCh38 --contig chr12 --offset 1234567 \
 
 By default, this extracts all alignments overlapping with the subgraph and clips them to the subgraph.
 Use option `--alignments overlapping` to avoid clipping or `--alignments contained` to select only alignments fully within the subgraph.
+
+If the subgraph is not needed, GAF-only output (to stdout) can be selected with option `--gaf-only`:
+
+```sh
+gbz-base query --sample GRCh38 --contig chr12 --offset 1234567 \
+    --gaf-base reads.db --gaf-only \
+    graph.db > out.gaf
+```
 
 The GBZ-base can be for the graph the reads were aligned to, or for any supergraph.
 For example, a GBZ-base for a clipped (default) Minigraph–Cactus graph can be used with reads aligned to a corresponding frequency-filtered or personalized (haplotype-sampled) graph.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,7 +14,8 @@
   * Old binaries are deprecated but still available.
 * Parameter presets for short and long reads in `gaf-base sort` and `gaf-base construct`.
 * Query improvements:
-  * Option for no haplotype output.
+  * Haplotype output selection with `--haplotypes`, with an option for no haplotypes.
+  * Option `--gaf-only` for writing the alignments instead of the subgraph to stdout.
 * Bug fixes:
   * `gaf-base decompress` works correctly with a reference-free GAF-base.
   * Multithreaded stable GAF sorting works correctly.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,6 +13,8 @@
   * `gaf-base decompress` replaces `db2gaf`.
   * Old binaries are deprecated but still available.
 * Parameter presets for short and long reads in `gaf-base sort` and `gaf-base construct`.
+* Query improvements:
+  * Option for no haplotype output.
 * Bug fixes:
   * `gaf-base decompress` works correctly with a reference-free GAF-base.
   * Multithreaded stable GAF sorting works correctly.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,7 @@
 * Query improvements:
   * Haplotype output selection with `--haplotypes`, with an option for no haplotypes.
   * Option `--gaf-only` for writing the alignments instead of the subgraph to stdout.
+  * Safety limit for subgraph size can be set for all query types.
 * Bug fixes:
   * `gaf-base decompress` works correctly with a reference-free GAF-base.
   * Multithreaded stable GAF sorting works correctly.

--- a/src/bin/gbz-base.rs
+++ b/src/bin/gbz-base.rs
@@ -119,6 +119,25 @@ fn construct(args: ConstructArgs) -> Result<()> {
 //-----------------------------------------------------------------------------
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum HaplotypeSelection {
+    All,
+    Distinct,
+    ReferenceOnly,
+    None,
+}
+
+impl From<HaplotypeSelection> for HaplotypeOutput {
+    fn from(value: HaplotypeSelection) -> Self {
+        match value {
+            HaplotypeSelection::All => HaplotypeOutput::All,
+            HaplotypeSelection::Distinct => HaplotypeOutput::Distinct,
+            HaplotypeSelection::ReferenceOnly => HaplotypeOutput::ReferenceOnly,
+            HaplotypeSelection::None => HaplotypeOutput::None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 enum OutputFormat {
     Gfa,
     Json,
@@ -198,17 +217,9 @@ struct QueryArgs {
     #[arg(long, value_name = "FILE")]
     chains: Option<String>,
 
-    /// Output distinct haplotypes with weights
-    #[arg(long)]
-    distinct: bool,
-
-    /// Output the reference but no other haplotypes
-    #[arg(long)]
-    reference_only: bool,
-
-    /// Output no haplotypes
-    #[arg(long)]
-    no_haplotypes: bool,
+    /// Haplotype output selection
+    #[arg(long, value_name = "SELECTION", value_enum, default_value_t = HaplotypeSelection::All)]
+    haplotypes: HaplotypeSelection,
 
     /// Output CIGAR strings for the haplotypes
     #[arg(long)]
@@ -226,6 +237,10 @@ struct QueryArgs {
     #[arg(long, value_name = "FILE")]
     gaf_output: Option<String>,
 
+    /// Write GAF output to stdout (no subgraph output)
+    #[arg(long)]
+    gaf_only: bool,
+
     /// Alignment selection (for GAF output)
     #[arg(long, value_name = "SELECTION", value_enum, default_value_t = AlignmentSelection::Clipped)]
     alignments: AlignmentSelection,
@@ -239,12 +254,13 @@ struct QueryConfig {
     format: OutputFormat,
     gaf_base: Option<String>,
     gaf_output: Option<String>,
+    gaf_only: bool,
     alignment_output: AlignmentOutput,
 }
 
 impl QueryConfig {
     fn write_gaf(&self) -> bool {
-        self.gaf_base.is_some() && self.gaf_output.is_some()
+        self.gaf_base.is_some() && (self.gaf_output.is_some() || self.gaf_only)
     }
 }
 
@@ -295,6 +311,7 @@ fn build_query_config(args: QueryArgs) -> Result<QueryConfig> {
         format: args.format,
         gaf_base: args.gaf_base,
         gaf_output: args.gaf_output,
+        gaf_only: args.gaf_only,
         alignment_output: args.alignments.into(),
     })
 }
@@ -323,14 +340,7 @@ fn build_subgraph_query(args: &QueryArgs) -> Result<SubgraphQuery> {
         (false, true) => SnarlOutput::Overlapping,
         (false, false) => SnarlOutput::None,
     };
-    let mut output = HaplotypeOutput::All;
-    if args.distinct {
-        output = HaplotypeOutput::Distinct;
-    } else if args.reference_only {
-        output = HaplotypeOutput::ReferenceOnly;
-    } else if args.no_haplotypes {
-        output = HaplotypeOutput::None;
-    }
+    let output = args.haplotypes.into();
 
     let query = if let Some(offset) = args.offset {
         SubgraphQuery::path_offset(&path_name.unwrap(), offset)
@@ -401,6 +411,9 @@ fn subgraph_statistics(subgraph: &Subgraph) {
 }
 
 fn write_subgraph(subgraph: &Subgraph, config: &QueryConfig) -> Result<()> {
+    if config.gaf_only {
+        return Ok(());
+    }
     let mut output = io::stdout().lock();
     match config.format {
         OutputFormat::Gfa => subgraph.write_gfa(&mut output, config.cigar).map_err(Error::io),
@@ -435,10 +448,15 @@ fn extract_gaf(graph: GraphReference<'_, '_>, subgraph: &Subgraph, config: &Quer
         );
     }
 
-    let gaf_output_file = config.gaf_output.as_ref().unwrap();
-    let mut options = OpenOptions::new();
-    options.write(true).create(true).truncate(true);
-    let mut gaf_output = options.open(gaf_output_file)?;
+    let (gaf_output_file, mut gaf_output) = if config.gaf_only {
+        (String::from("stdout"), Box::new(io::stdout().lock()) as Box<dyn io::Write>)
+    } else {
+        let gaf_output_file = config.gaf_output.as_ref().unwrap();
+        let mut options = OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        let gaf_output = options.open(gaf_output_file)?;
+        (gaf_output_file.clone(), Box::new(gaf_output) as Box<dyn io::Write>)
+    };
     formats::write_gaf_file_header(&mut gaf_output).map_err(
         |x| Error::io(format!("Failed to write GAF header to {}: {}", gaf_output_file, x))
     )?;

--- a/src/bin/gbz-base.rs
+++ b/src/bin/gbz-base.rs
@@ -206,6 +206,10 @@ struct QueryArgs {
     #[arg(long)]
     reference_only: bool,
 
+    /// Output no haplotypes
+    #[arg(long)]
+    no_haplotypes: bool,
+
     /// Output CIGAR strings for the haplotypes
     #[arg(long)]
     cigar: bool,
@@ -322,9 +326,10 @@ fn build_subgraph_query(args: &QueryArgs) -> Result<SubgraphQuery> {
     let mut output = HaplotypeOutput::All;
     if args.distinct {
         output = HaplotypeOutput::Distinct;
-    }
-    if args.reference_only {
+    } else if args.reference_only {
         output = HaplotypeOutput::ReferenceOnly;
+    } else if args.no_haplotypes {
+        output = HaplotypeOutput::None;
     }
 
     let query = if let Some(offset) = args.offset {
@@ -346,7 +351,7 @@ fn build_subgraph_query(args: &QueryArgs) -> Result<SubgraphQuery> {
         SubgraphQuery::nodes(nodes)
     };
 
-    Ok(query.with_context(args.context).with_snarls(snarls).with_output(output))
+    Ok(query.with_context(args.context).with_snarls(snarls).with_haplotypes(output))
 }
 
 fn parse_interval(s: &str) -> Result<Range<usize>> {

--- a/src/bin/gbz-base.rs
+++ b/src/bin/gbz-base.rs
@@ -197,7 +197,7 @@ struct QueryArgs {
     #[arg(short, long, value_name = "INT[+-]:INT[+-]")]
     between: Option<String>,
 
-    /// Safety limit for the number of nodes in --between
+    /// Safety limit for the number of nodes in the subgraph
     #[arg(long, value_name = "INT", value_parser = parse_quantity)]
     limit: Option<usize>,
 
@@ -349,7 +349,7 @@ fn build_subgraph_query(args: &QueryArgs) -> Result<SubgraphQuery> {
         SubgraphQuery::path_interval(&path_name.unwrap(), interval)
     } else if let Some(s) = &args.between {
         let (start, end) = parse_between(s)?;
-        SubgraphQuery::between(start, end, args.limit)
+        SubgraphQuery::between(start, end)
     } else {
         let mut nodes = Vec::with_capacity(args.node.len() + args.handle.len());
         for id in &args.node {
@@ -361,7 +361,7 @@ fn build_subgraph_query(args: &QueryArgs) -> Result<SubgraphQuery> {
         SubgraphQuery::nodes(nodes)
     };
 
-    Ok(query.with_context(args.context).with_snarls(snarls).with_haplotypes(output))
+    Ok(query.with_limit(args.limit).with_context(args.context).with_snarls(snarls).with_haplotypes(output))
 }
 
 fn parse_interval(s: &str) -> Result<Range<usize>> {

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -315,7 +315,7 @@ impl Config {
             SubgraphQuery::path_interval(&path_name.unwrap(), interval)
         } else if let Some(s) = matches.opt_str("between") {
             let (start, end) = Self::parse_between(&s)?;
-            SubgraphQuery::between(start, end, limit)
+            SubgraphQuery::between(start, end)
         } else {
             let node_strings = matches.opt_strs("node");
             let handle_strings = matches.opt_strs("handle");
@@ -331,7 +331,7 @@ impl Config {
             SubgraphQuery::nodes(nodes)
         };
 
-        Ok(query.with_context(context).with_snarls(snarls).with_haplotypes(output))
+        Ok(query.with_limit(limit).with_context(context).with_snarls(snarls).with_haplotypes(output))
     }
 }
 

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -331,7 +331,7 @@ impl Config {
             SubgraphQuery::nodes(nodes)
         };
 
-        Ok(query.with_context(context).with_snarls(snarls).with_output(output))
+        Ok(query.with_context(context).with_snarls(snarls).with_haplotypes(output))
     }
 }
 

--- a/src/read_set/tests.rs
+++ b/src/read_set/tests.rs
@@ -8,9 +8,9 @@ use crate::internal;
 
 fn gaf_base_subgraph_queries() -> Vec<(SubgraphQuery, String)> {
     vec![
-        (SubgraphQuery::nodes(vec![]).with_context(100).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::All), String::from("empty")),
-        (SubgraphQuery::nodes(vec![1000]).with_context(100).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::All), String::from("single component")),
-        (SubgraphQuery::nodes(vec![500, 1500]).with_context(100).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::All), String::from("two components")),
+        (SubgraphQuery::nodes(vec![]).with_context(100).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::All), String::from("empty")),
+        (SubgraphQuery::nodes(vec![1000]).with_context(100).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::All), String::from("single component")),
+        (SubgraphQuery::nodes(vec![500, 1500]).with_context(100).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::All), String::from("two components")),
     ]
 }
 

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -609,6 +609,9 @@ impl Subgraph {
         Ok((inserted, removed))
     }
 
+    // FIXME: safety limit should be handled by add_node_internal
+    // FIXME: and it should be stored in the subgraph (either from a query or with an appropriate setter)
+    // FIXME: then we can test it with every query in the tests: None to get n, Some(n-1) to get an error, Some(n) query successfully
     /// Inserts all nodes between the given two handles into the subgraph.
     ///
     /// If `start` and `end` are in the same chain in the given order, this will insert all nodes and snarls between them.
@@ -1048,6 +1051,9 @@ impl Subgraph {
         output: HaplotypeOutput
     ) -> Result<()> {
         self.clear_paths();
+        if output == HaplotypeOutput::None {
+            return Ok(());
+        }
 
         let ref_pos;
         if let Some((position, name)) = reference_path {

--- a/src/subgraph.rs
+++ b/src/subgraph.rs
@@ -6,7 +6,7 @@
 //! All other paths within the subgraph can also be extracted, but they will not have any true metadata associated with them.
 
 use crate::{GBZRecord, GBZPath};
-use crate::error::{Error, Result};
+use crate::{Error, Result};
 use crate::{GraphInterface, GraphReference};
 use crate::PathIndex;
 use crate::{SubgraphQuery, HaplotypeOutput, SnarlOutput};
@@ -56,6 +56,12 @@ pub mod query;
 /// * [`Subgraph::extract_snarls`] to extend the subgraph with overlapping top-level snarls.
 ///
 /// [`Subgraph::from_gbz`] and [`Subgraph::from_db`] are integrated methods for extracting a subgraph with paths using a [`SubgraphQuery`].
+///
+/// A safety limit for the size of the subgraph can be set with [`Subgraph::set_limit`].
+/// It can be used to avoid extracting a much larger subgraph than intended, which could lead to excessive memory usage.
+/// If the safety limit is exceeded, the operation will abort and return [`ErrorKind::LimitExceeded`](crate::ErrorKind::LimitExceeded).
+/// Note that nodes between the nearest indexed position and the query position count towards the limit in a path-based query.
+/// This may cause the limit to be exceeded even if the final subgraph is within the limit.
 ///
 /// `Subgraph` implements a similar graph interface to the node/edge operations of [`GBZ`].
 /// It can also be serialized in GFA and JSON formats using [`Subgraph::write_gfa`] and [`Subgraph::write_json`].
@@ -128,6 +134,9 @@ pub struct Subgraph {
     // Node records for the subgraph.
     records: BTreeMap<usize, GBZRecord>,
 
+    // Safety limit for the number of nodes in the subgraph.
+    limit: Option<usize>,
+
     // Paths in the subgraph.
     paths: Vec<PathInfo>,
 
@@ -151,6 +160,14 @@ impl Subgraph {
     /// Creates a new empty subgraph.
     pub fn new() -> Self {
         Subgraph::default()
+    }
+
+    /// Sets a safety limit for the size of the subgraph in nodes.
+    ///
+    /// Any query or operation updating the subgraph will abort if the limit would be exceeded.
+    /// The return value will then be [`ErrorKind::LimitExceeded`](crate::ErrorKind::LimitExceeded).
+    pub fn set_limit(&mut self, limit: Option<usize>) {
+        self.limit = limit;
     }
 
     /// Returns the path position for the haplotype offset represented by the query position.
@@ -609,13 +626,11 @@ impl Subgraph {
         Ok((inserted, removed))
     }
 
-    // FIXME: safety limit should be handled by add_node_internal
-    // FIXME: and it should be stored in the subgraph (either from a query or with an appropriate setter)
-    // FIXME: then we can test it with every query in the tests: None to get n, Some(n-1) to get an error, Some(n) query successfully
     /// Inserts all nodes between the given two handles into the subgraph.
     ///
     /// If `start` and `end` are in the same chain in the given order, this will insert all nodes and snarls between them.
-    /// Otherwise the behavior will be unpredictable and it is recommended to set a safety limit to avoid excessive memory usage.
+    /// Otherwise the behavior will be unpredictable.
+    /// It is recommended to set a safety limit with [`Subgraph::set_limit`] to avoid excessive memory usage.
     /// Removes all path information.
     /// Returns the number of inserted nodes.
     ///
@@ -624,7 +639,6 @@ impl Subgraph {
     /// * `graph`: A GBZ-compatible graph.
     /// * `start`: Start handle (inclusive).
     /// * `end`: End handle (inclusive).
-    /// * `limit`: Optional safety limit on the number of inserted nodes.
     ///
     /// # Errors
     ///
@@ -646,13 +660,13 @@ impl Subgraph {
     /// let start = support::encode_node(14, Orientation::Forward);
     /// let end = support::encode_node(17, Orientation::Forward);
     /// let mut subgraph = Subgraph::new();
-    /// let result = subgraph.between_nodes(GraphReference::Gbz(&graph), start, end, None);
+    /// let result = subgraph.between_nodes(GraphReference::Gbz(&graph), start, end);
     /// assert_eq!(result, Ok(4));
     ///
     /// let expected_nodes = [14, 15, 16, 17];
     /// assert!(subgraph.node_iter().eq(expected_nodes.iter().copied()));
     /// ```
-    pub fn between_nodes(&mut self, graph: GraphReference<'_, '_>, start: usize, end: usize, limit: Option<usize>) -> Result<usize> {
+    pub fn between_nodes(&mut self, graph: GraphReference<'_, '_>, start: usize, end: usize) -> Result<usize> {
         self.clear_paths();
 
         // Active handles. We proceed to their successors but not predecessors.
@@ -669,11 +683,6 @@ impl Subgraph {
         while let Some(curr) = active.pop() {
             let (node_id, orientation) = support::decode_node(curr);
             if !self.has_node(node_id) {
-                if let Some(limit) = limit && inserted >= limit {
-                    let (start_id, start_o) = support::decode_node(start);
-                    let (end_id, end_o) = support::decode_node(end);
-                    return Err(Error::limit_exceeded(format!("Found more than {} new nodes between ({}, {}) and ({}, {})", limit, start_id, start_o, end_id, end_o)));
-                }
                 self.add_node_internal(&mut graph, node_id)?;
                 inserted += 1;
             }
@@ -750,10 +759,10 @@ impl Subgraph {
         for (start, end) in boundary_nodes {
             match &mut graph {
                 GraphReference::Gbz(graph) => {
-                    inserted += self.between_nodes(GraphReference::Gbz(graph), start, end, None)?;
+                    inserted += self.between_nodes(GraphReference::Gbz(graph), start, end)?;
                 }
                 GraphReference::Db(graph) => {
-                    inserted += self.between_nodes(GraphReference::Db(graph), start, end, None)?;
+                    inserted += self.between_nodes(GraphReference::Db(graph), start, end)?;
                 },
                 GraphReference::None => {
                     return Err(Error::invalid_query("No graph reference provided"));
@@ -829,6 +838,8 @@ impl Subgraph {
         if (query.snarls() != SnarlOutput::None) && chains.is_none() {
             return Err(Error::invalid_query("Top-level chains are required for extracting snarls"));
         }
+        self.set_limit(query.limit());
+
         match query.query_type() {
             QueryType::PathOffset(query_pos) => {
                 let path_index = path_index.ok_or_else(||
@@ -859,11 +870,11 @@ impl Subgraph {
                 self.extract_snarls(GraphReference::Gbz(graph), query.snarls(), chains)?;
                 self.extract_paths(None, query.output())?;
             },
-            QueryType::Between((start, end), limit) => {
+            QueryType::Between(start, end) => {
                 if query.output() == HaplotypeOutput::ReferenceOnly {
                     return Err(Error::invalid_query("Cannot output a reference path in a node-based query"));
                 }
-                self.between_nodes(GraphReference::Gbz(graph), *start, *end, *limit)?;
+                self.between_nodes(GraphReference::Gbz(graph), *start, *end)?;
                 self.extract_paths(None, query.output())?;
             },
         }
@@ -932,6 +943,8 @@ impl Subgraph {
     /// fs::remove_file(&db_file).unwrap();
     /// ```
     pub fn from_db<'reference, 'graph>(&mut self, graph: &'reference mut GraphInterface<'graph>, query: &SubgraphQuery) -> Result<()> {
+        self.set_limit(query.limit());
+
         match query.query_type() {
             QueryType::PathOffset(query_pos) => {
                 let reference_path = self.path_pos_from_db(graph, query_pos)?;
@@ -956,11 +969,11 @@ impl Subgraph {
                 self.extract_snarls(GraphReference::Db(graph), query.snarls(), None)?;
                 self.extract_paths(None, query.output())?;
             },
-            QueryType::Between((start, end), limit) => {
+            QueryType::Between(start, end) => {
                 if query.output() == HaplotypeOutput::ReferenceOnly {
                     return Err(Error::invalid_query("Cannot output a reference path in a node-based query"));
                 }
-                self.between_nodes(GraphReference::Db(graph), *start, *end, *limit)?;
+                self.between_nodes(GraphReference::Db(graph), *start, *end)?;
                 self.extract_paths(None, query.output())?;
             },
         }
@@ -1173,7 +1186,13 @@ impl Subgraph {
     }
 
     // Adds a new node to the subgraph.
+    // We assume that the node is not already in the subgraph.
+    // The safety limit for subgraph size is checked here.
     fn add_node_internal(&mut self, graph: &mut GraphReference<'_, '_>, node_id: usize) -> Result<()> {
+        if let Some(limit) = self.limit && self.nodes() >= limit {
+            return Err(Error::limit_exceeded(format!("Subgraph size limit of {} nodes exceeded", limit)));
+        }
+
         let forward = graph.gbz_record(support::encode_node(node_id, Orientation::Forward))?;
         let reverse = graph.gbz_record(support::encode_node(node_id, Orientation::Reverse))?;
         self.records.insert(forward.handle(), forward);
@@ -1576,6 +1595,14 @@ impl Subgraph {
     #[inline]
     fn record(&self, handle: usize) -> Option<&GBZRecord> {
         self.records.get(&handle)
+    }
+
+    /// Returns the safety limit for the size of the subgraph in nodes.
+    ///
+    /// Returns [`None`] if the limit is not set.
+    #[inline]
+    pub fn limit(&self) -> Option<usize> {
+        self.limit
     }
 
     /// Returns the number of paths in the subgraph.

--- a/src/subgraph/query.rs
+++ b/src/subgraph/query.rs
@@ -17,6 +17,8 @@ pub enum HaplotypeOutput {
     Distinct,
     /// Output only the reference path.
     ReferenceOnly,
+    /// No haplotypes in the output.
+    None,
 }
 
 impl Display for HaplotypeOutput {
@@ -25,6 +27,7 @@ impl Display for HaplotypeOutput {
             HaplotypeOutput::All => write!(f, "all"),
             HaplotypeOutput::Distinct => write!(f, "distinct"),
             HaplotypeOutput::ReferenceOnly => write!(f, "reference only"),
+            HaplotypeOutput::None => write!(f, "none"),
         }
     }
 }
@@ -58,6 +61,7 @@ pub(super) enum QueryType {
     PathInterval(FullPathName, usize),
     // Set of node identifiers.
     Nodes(BTreeSet<usize>),
+    // FIXME: safety limit should be in the query itself
     // Subgraph between two handles in the same chain, with an optional safety limit for the number of nodes extracted.
     Between((usize, usize), Option<usize>),
 }
@@ -153,6 +157,7 @@ impl SubgraphQuery {
         }
     }
 
+    // FIXME: move limit to with_limit
     /// Creates a query that extracts a subgraph between two handles in the same chain.
     ///
     /// This query ignores context length and the snarl extraction flag.
@@ -181,6 +186,11 @@ impl SubgraphQuery {
         SubgraphQuery { snarls, ..self }
     }
 
+    #[deprecated(since = "0.6.0", note = "Use `with_haplotypes` instead")]
+    pub fn with_output(self, output: HaplotypeOutput) -> Self {
+        self.with_haplotypes(output)
+    }
+
     /// Returns an updated query with the given haplotype output option.
     ///
     /// See [`Self::DEFAULT_OUTPUT`] for the default value.
@@ -188,7 +198,7 @@ impl SubgraphQuery {
     /// # Panics
     ///
     /// Panics if this is a node-based query and the output would be [`HaplotypeOutput::ReferenceOnly`].
-    pub fn with_output(self, output: HaplotypeOutput) -> Self {
+    pub fn with_haplotypes(self, output: HaplotypeOutput) -> Self {
         if self.is_node_based() {
             assert!(output != HaplotypeOutput::ReferenceOnly, "Reference-only output is not supported for node-based queries");
         }

--- a/src/subgraph/query.rs
+++ b/src/subgraph/query.rs
@@ -61,9 +61,8 @@ pub(super) enum QueryType {
     PathInterval(FullPathName, usize),
     // Set of node identifiers.
     Nodes(BTreeSet<usize>),
-    // FIXME: safety limit should be in the query itself
-    // Subgraph between two handles in the same chain, with an optional safety limit for the number of nodes extracted.
-    Between((usize, usize), Option<usize>),
+    // Subgraph between two handles in the same chain.
+    Between(usize, usize),
 }
 
 //-----------------------------------------------------------------------------
@@ -82,6 +81,9 @@ pub(super) enum QueryType {
 /// assert_eq!(query.snarls(), SubgraphQuery::DEFAULT_SNARLS);
 /// assert_eq!(query.output(), SubgraphQuery::DEFAULT_OUTPUT);
 ///
+/// let query = query.with_limit(Some(100));
+/// assert_eq!(query.limit(), Some(100));
+///
 /// let query = query.with_context(1000);
 /// assert_eq!(query.context(), 1000);
 ///
@@ -94,6 +96,9 @@ pub(super) enum QueryType {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SubgraphQuery {
     query_type: QueryType,
+
+    // Optional safety limit for the size of the subgraph in nodes.
+    limit: Option<usize>,
 
     // Context size around the query position(s) in bp.
     context: usize,
@@ -125,6 +130,7 @@ impl SubgraphQuery {
         path_name.fragment = offset;
         SubgraphQuery {
             query_type: QueryType::PathOffset(path_name),
+            limit: None,
             context: Self::DEFAULT_CONTEXT,
             snarls: Self::DEFAULT_SNARLS,
             output: Self::DEFAULT_OUTPUT,
@@ -141,6 +147,7 @@ impl SubgraphQuery {
         path_name.fragment = interval.start;
         SubgraphQuery {
             query_type: QueryType::PathInterval(path_name, interval.len()),
+            limit: None,
             context: Self::DEFAULT_CONTEXT,
             snarls: Self::DEFAULT_SNARLS,
             output: Self::DEFAULT_OUTPUT,
@@ -151,25 +158,30 @@ impl SubgraphQuery {
     pub fn nodes(nodes: impl IntoIterator<Item = usize>) -> Self {
         SubgraphQuery {
             query_type: QueryType::Nodes(nodes.into_iter().collect()),
+            limit: None,
             context: Self::DEFAULT_CONTEXT,
             snarls: Self::DEFAULT_SNARLS,
             output: Self::DEFAULT_OUTPUT,
         }
     }
 
-    // FIXME: move limit to with_limit
     /// Creates a query that extracts a subgraph between two handles in the same chain.
     ///
     /// This query ignores context length and the snarl extraction flag.
-    /// An optional safety limit for the size of the subgraph in nodes can be provided.
     /// If the nodes are not in the same chain in the given order, the subgraph can otherwise be arbitrarily large.
-    pub fn between(start: usize, end: usize, limit: Option<usize>) -> Self {
+    pub fn between(start: usize, end: usize) -> Self {
         SubgraphQuery {
-            query_type: QueryType::Between((start, end), limit),
+            query_type: QueryType::Between(start, end),
+            limit: None,
             context: Self::DEFAULT_CONTEXT,
             snarls: Self::DEFAULT_SNARLS,
             output: Self::DEFAULT_OUTPUT,
         }
+    }
+
+    /// Returns an updated query with the given limit for the size of the subgraph in nodes.
+    pub fn with_limit(self, limit: Option<usize>) -> Self {
+        SubgraphQuery { limit, ..self }
     }
 
     /// Returns an updated query with the given context length.
@@ -209,7 +221,7 @@ impl SubgraphQuery {
         &self.query_type
     }
 
-    /// Returns `true` if this is a reference-based query.
+    /// Returns `true` if this is a reference-based / path-based query.
     pub fn is_reference_based(&self) -> bool {
         matches!(self.query_type, QueryType::PathOffset(_) | QueryType::PathInterval(_, _))
     }
@@ -222,6 +234,11 @@ impl SubgraphQuery {
     /// Returns `true` if this is a multi-node query.
     pub fn is_multi_node(&self) -> bool {
         matches!(self.query_type, QueryType::Nodes(ref nodes) if nodes.len() > 1)
+    }
+
+    /// Returns the safety limit for the size of the subgraph in nodes.
+    pub fn limit(&self) -> Option<usize> {
+        self.limit
     }
 
     /// Returns the context length (in bp) for the query.
@@ -242,26 +259,34 @@ impl SubgraphQuery {
 
 impl Display for SubgraphQuery {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let context_str = match self.snarls() {
-            SnarlOutput::None => format!("{}", self.context),
-            SnarlOutput::Contained => format!("{} with contained snarls", self.context),
-            SnarlOutput::Overlapping => format!("{} with overlapping snarls", self.context),
-        };
+        // Query itself.
         match self.query_type() {
-            QueryType::PathOffset(path_name) => write!(f, "(path {}, context {}, {})", path_name, context_str, self.output),
-            QueryType::PathInterval(path_name, len) => write!(f, "(path {}, len {}, context {}, {})", path_name, len, context_str, self.output),
-            QueryType::Nodes(nodes) => write!(f, "(nodes {:#?}, context {}, {})", nodes, context_str, self.output),
-            QueryType::Between((start, end), limit) => {
+            QueryType::PathOffset(path_name) => write!(f, "(path {}", path_name)?,
+            QueryType::PathInterval(path_name, len) => write!(f, "(path {}, len {}", path_name, len)?,
+            QueryType::Nodes(nodes) => write!(f, "(nodes {:#?}", nodes)?,
+            QueryType::Between(start, end) => {
                 let (start_id, start_o) = support::decode_node(*start);
                 let (end_id, end_o) = support::decode_node(*end);
-                let limit_str = if let Some(limit) = limit {
-                    format!(", limit {}", limit)
-                } else {
-                    String::new()
-                };
-                write!(f, "(between ({} {}) and ({} {}){}, {})", start_id, start_o, end_id, end_o, limit_str, self.output)
-            },
+                write!(f, "(between ({} {}) and ({} {})", start_id, start_o, end_id, end_o)?;
+            }
         }
+
+        // Safety limit.
+        if let Some(limit) = self.limit() {
+            write!(f, ", limit {}", limit)?;
+        }
+
+        // Context length and snarls.
+        match self.snarls() {
+            SnarlOutput::None => write!(f, ", context {}", self.context)?,
+            SnarlOutput::Contained => write!(f, ", context {} with contained snarls", self.context)?,
+            SnarlOutput::Overlapping => write!(f, ", context {} with overlapping snarls", self.context)?,
+        }
+
+        // Haplotype output.
+        write!(f, ", {})", self.output)?;
+
+        Ok(())
     }
 }
 

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use crate::GBZBase;
+use crate::ErrorKind;
 use crate::{formats, internal, utils};
 
 use gbz::algorithms::find_chains;
@@ -493,8 +494,8 @@ fn queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, usize)>) {
         SubgraphQuery::path_interval(&path_a, 1..4).with_context(0).with_snarls(SnarlOutput::Overlapping).with_haplotypes(HaplotypeOutput::All),
 
         // A snarl in both orientations.
-        SubgraphQuery::between(support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward), None).with_haplotypes(HaplotypeOutput::All),
-        SubgraphQuery::between(support::encode_node(14, Orientation::Reverse), support::encode_node(11, Orientation::Reverse), None).with_haplotypes(HaplotypeOutput::All),
+        SubgraphQuery::between(support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward)).with_haplotypes(HaplotypeOutput::All),
+        SubgraphQuery::between(support::encode_node(14, Orientation::Reverse), support::encode_node(11, Orientation::Reverse)).with_haplotypes(HaplotypeOutput::All),
 
         // We can find the same snarl starting from an internal node.
         SubgraphQuery::nodes([12]).with_context(0).with_snarls(SnarlOutput::Overlapping).with_haplotypes(HaplotypeOutput::All),
@@ -779,6 +780,105 @@ fn subgraph_from_db() {
 
 //-----------------------------------------------------------------------------
 
+fn max_temporary_nodes(query: &SubgraphQuery, final_nodes: &[usize]) -> usize {
+    let expected_nodes = final_nodes.len();
+    if !query.is_reference_based() {
+        return expected_nodes;
+    }
+
+    // We must include all nodes starting from the nearest indexed position that
+    // are not in the final subgraph. This assumes that the indexed position is
+    // at the start of the path.
+    const PATH_A: &[usize] = &[11, 12, 14, 15, 17];
+    const PATH_B: &[usize] = &[21, 22, 24, 25];
+    for ref_path in [PATH_A, PATH_B] {
+        for offset in 0..ref_path.len() {
+            let node_id = ref_path[offset];
+            if final_nodes.contains(&node_id) {
+                return expected_nodes + offset;
+            }
+        }
+    }
+
+    expected_nodes
+}
+
+fn expect_limit_exceeded(result: Result<()>, query: &SubgraphQuery) {
+    match result {
+        Ok(_) => {
+            panic!("Query {} should have failed due to limit", query);
+        },
+        Err(err) => {
+            assert_eq!(err.kind(), ErrorKind::LimitExceeded, "Query {} failed with unexpected error: {}", query, err);
+        },
+    }
+}
+
+#[test]
+fn subgraph_from_gbz_with_limit() {
+    let (graph, path_index) = internal::load_gbz_and_create_path_index("example.gbz", GBZBase::INDEX_INTERVAL);
+    let chains = internal::load_chains("example.chains");
+    let (queries, truth) = queries_and_truth();
+    for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
+        if true_nodes.is_empty() {
+            continue;
+        }
+
+        let failing_query = query.clone().with_limit(Some(true_nodes.len() - 1));
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_gbz(&graph, Some(&path_index), Some(&chains), &failing_query);
+        expect_limit_exceeded(result, &failing_query);
+
+        let limit = max_temporary_nodes(&query, &true_nodes);
+        let successful_query = query.clone().with_limit(Some(limit));
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_gbz(&graph, Some(&path_index), Some(&chains), &successful_query);
+        if let Err(err) = result {
+            panic!("Failed to create subgraph for query {}: {}", successful_query, err);
+        }
+        check_subgraph(&graph, &subgraph, &true_nodes, *path_count, &successful_query.to_string());
+    }
+}
+
+#[test]
+fn subgraph_from_db_with_limit() {
+    let gbz_file = support::get_test_data("example.gbz");
+    let gbz_graph: GBZ = serialize::load_from(&gbz_file).unwrap();
+    let chains_file = utils::get_test_data("example.chains");
+    let db_file = serialize::temp_file_name("subgraph-from-db");
+    let result = GBZBase::create_from_files(&gbz_file, Some(&chains_file), &db_file);
+    assert!(result.is_ok(), "Failed to create database: {}", result.unwrap_err());
+    let mut database = GBZBase::open(&db_file).unwrap();
+    let mut graph = GraphInterface::new(&mut database).unwrap();
+
+    let (queries, truth) = queries_and_truth();
+    for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
+        if true_nodes.is_empty() {
+            continue;
+        }
+
+        let failing_query = query.clone().with_limit(Some(true_nodes.len() - 1));
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_db(&mut graph, &failing_query);
+        expect_limit_exceeded(result, &failing_query);
+
+        let limit = max_temporary_nodes(&query, &true_nodes);
+        let successful_query = query.clone().with_limit(Some(limit));
+        let mut subgraph = Subgraph::new();
+        let result = subgraph.from_db(&mut graph, &successful_query);
+        if let Err(err) = result {
+            panic!("Failed to create subgraph for query {}: {}", successful_query, err);
+        }
+        check_subgraph(&gbz_graph, &subgraph, &true_nodes, *path_count, &successful_query.to_string());
+    }
+
+    drop(graph);
+    drop(database);
+    fs::remove_file(&db_file).unwrap();
+}
+
+//-----------------------------------------------------------------------------
+
 #[test]
 fn manual_gbz_queries() {
     let (graph, path_index) = internal::load_gbz_and_create_path_index("example.gbz", GBZBase::INDEX_INTERVAL);
@@ -786,6 +886,7 @@ fn manual_gbz_queries() {
     let (queries, truth) = queries_and_truth();
     for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
         let mut subgraph = Subgraph::new();
+        subgraph.set_limit(query.limit());
         let mut reference_path = None;
         match query.query_type() {
             QueryType::PathOffset(query_pos) => {
@@ -818,8 +919,8 @@ fn manual_gbz_queries() {
                     panic!("Query {} failed: {}", query, err);
                 }
             },
-            QueryType::Between((start, end), limit) => {
-                let result = subgraph.between_nodes(GraphReference::Gbz(&graph), *start, *end, *limit);
+            QueryType::Between(start, end) => {
+                let result = subgraph.between_nodes(GraphReference::Gbz(&graph), *start, *end);
                 if let Err(err) = result {
                     panic!("Query {} failed: {}", query, err);
                 }
@@ -861,6 +962,7 @@ fn manual_db_queries() {
     let (queries, truth) = queries_and_truth();
     for (query, (true_nodes, path_count)) in queries.iter().zip(truth.iter()) {
         let mut subgraph = Subgraph::new();
+        subgraph.set_limit(query.limit());
         let mut reference_path = None;
         match query.query_type() {
             QueryType::PathOffset(query_pos) => {
@@ -893,8 +995,8 @@ fn manual_db_queries() {
                     panic!("Query {} failed: {}", query, err);
                 }
             },
-            QueryType::Between((start, end), limit) => {
-                let result = subgraph.between_nodes(GraphReference::Db(&mut graph), *start, *end, *limit);
+            QueryType::Between(start, end) => {
+                let result = subgraph.between_nodes(GraphReference::Db(&mut graph), *start, *end);
                 if let Err(err) = result {
                     panic!("Query {} failed: {}", query, err);
                 }
@@ -976,12 +1078,12 @@ fn duplicate_gbz_queries() {
                     Err(err) => panic!("Duplicate query {} failed: {}", query, err),
                 }
             },
-            QueryType::Between((start, end), limit) => {
-                let result = subgraph.between_nodes(GraphReference::Gbz(&graph), *start, *end, *limit);
+            QueryType::Between(start, end) => {
+                let result = subgraph.between_nodes(GraphReference::Gbz(&graph), *start, *end);
                 if let Err(err) = result {
                     panic!("Query {} failed: {}", query, err);
                 }
-                let result = subgraph.between_nodes(GraphReference::Gbz(&graph), *start, *end, *limit);
+                let result = subgraph.between_nodes(GraphReference::Gbz(&graph), *start, *end);
                 match result {
                     Ok(result) => assert_eq!(result, 0, "Duplicate query {} inserted nodes", query),
                     Err(err) => panic!("Duplicate query {} failed: {}", query, err),
@@ -1002,12 +1104,20 @@ fn between_nodes_with_limit() {
 
     for limit in 0..=expected {
         let mut subgraph = Subgraph::new();
-        let result = subgraph.between_nodes(GraphReference::Gbz(&graph), start, end, Some(limit));
+        subgraph.set_limit(Some(limit));
+        let result = subgraph.between_nodes(GraphReference::Gbz(&graph), start, end);
         if limit < expected {
-            if let Ok(inserted) = result {
-                panic!("Found {} nodes between ({} {}) and ({} {}) with limit {}; expected {}",
+            match result {
+                Ok(inserted) => panic!("Found {} nodes between ({} {}) and ({} {}) with limit {}; expected {}",
                     inserted, start_id, start_o, end_id, end_o, limit, expected
-                );
+                ),
+                Err(err) => {
+                    assert_eq!(
+                        err.kind(), ErrorKind::LimitExceeded,
+                        "Unexpected error for nodes between ({} {}) and ({} {}) with limit {}: {}",
+                        start_id, start_o, end_id, end_o, limit, err
+                    );
+                }
             }
         } else {
             if let Err(err) = result {

--- a/src/subgraph/tests.rs
+++ b/src/subgraph/tests.rs
@@ -475,30 +475,31 @@ fn queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, usize)>) {
     let path_a = FullPathName::generic("A");
     let path_b = FullPathName::generic("B");
     let queries = vec![
-        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::All),
-        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::Distinct),
-        SubgraphQuery::nodes([14]).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::Distinct),
-        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::ReferenceOnly),
-        SubgraphQuery::path_offset(&path_b, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::Distinct),
+        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::All),
+        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::Distinct),
+        SubgraphQuery::nodes([14]).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::Distinct),
+        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::ReferenceOnly),
+        SubgraphQuery::path_offset(&path_b, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::Distinct),
+        SubgraphQuery::path_offset(&path_b, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::None),
 
         // Path interval corresponding to a snarl with all snarl modes.
-        SubgraphQuery::path_interval(&path_a, 2..5).with_context(0).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::All),
-        SubgraphQuery::path_interval(&path_a, 2..5).with_context(0).with_snarls(SnarlOutput::Contained).with_output(HaplotypeOutput::All),
-        SubgraphQuery::path_interval(&path_a, 2..5).with_context(0).with_snarls(SnarlOutput::Overlapping).with_output(HaplotypeOutput::All),
+        SubgraphQuery::path_interval(&path_a, 2..5).with_context(0).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::All),
+        SubgraphQuery::path_interval(&path_a, 2..5).with_context(0).with_snarls(SnarlOutput::Contained).with_haplotypes(HaplotypeOutput::All),
+        SubgraphQuery::path_interval(&path_a, 2..5).with_context(0).with_snarls(SnarlOutput::Overlapping).with_haplotypes(HaplotypeOutput::All),
 
         // If we start 1 bp earlier (inside a snarl), we get another snarl as well.
-        SubgraphQuery::path_interval(&path_a, 1..5).with_context(0).with_snarls(SnarlOutput::Overlapping).with_output(HaplotypeOutput::All),
+        SubgraphQuery::path_interval(&path_a, 1..5).with_context(0).with_snarls(SnarlOutput::Overlapping).with_haplotypes(HaplotypeOutput::All),
         // The result does not change if we stop 1 bp earlier (inside a snarl).
-        SubgraphQuery::path_interval(&path_a, 1..4).with_context(0).with_snarls(SnarlOutput::Overlapping).with_output(HaplotypeOutput::All),
+        SubgraphQuery::path_interval(&path_a, 1..4).with_context(0).with_snarls(SnarlOutput::Overlapping).with_haplotypes(HaplotypeOutput::All),
 
         // A snarl in both orientations.
-        SubgraphQuery::between(support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward), None).with_output(HaplotypeOutput::All),
-        SubgraphQuery::between(support::encode_node(14, Orientation::Reverse), support::encode_node(11, Orientation::Reverse), None).with_output(HaplotypeOutput::All),
+        SubgraphQuery::between(support::encode_node(11, Orientation::Forward), support::encode_node(14, Orientation::Forward), None).with_haplotypes(HaplotypeOutput::All),
+        SubgraphQuery::between(support::encode_node(14, Orientation::Reverse), support::encode_node(11, Orientation::Reverse), None).with_haplotypes(HaplotypeOutput::All),
 
         // We can find the same snarl starting from an internal node.
-        SubgraphQuery::nodes([12]).with_context(0).with_snarls(SnarlOutput::Overlapping).with_output(HaplotypeOutput::All),
+        SubgraphQuery::nodes([12]).with_context(0).with_snarls(SnarlOutput::Overlapping).with_haplotypes(HaplotypeOutput::All),
         // If we start from a boundary node, we do not extract the snarl.
-        SubgraphQuery::nodes([11]).with_context(0).with_snarls(SnarlOutput::Overlapping).with_output(HaplotypeOutput::All),
+        SubgraphQuery::nodes([11]).with_context(0).with_snarls(SnarlOutput::Overlapping).with_haplotypes(HaplotypeOutput::All),
     ];
     let truth = vec![
         (vec![12, 13, 14, 15, 16], 3),
@@ -506,6 +507,7 @@ fn queries_and_truth() -> (Vec<SubgraphQuery>, Vec<(Vec<usize>, usize)>) {
         (vec![12, 13, 14, 15, 16], 2),
         (vec![12, 13, 14, 15, 16], 1),
         (vec![22, 23, 24, 25], 2),
+        (vec![22, 23, 24, 25], 0),
 
         (vec![14, 15, 17], 4),
         (vec![14, 15, 16, 17], 3),
@@ -529,11 +531,12 @@ fn queries_and_gfas(cigar: bool) -> (Vec<SubgraphQuery>, Vec<Vec<String>>){
     let path_a = FullPathName::generic("A");
     let path_b = FullPathName::generic("B");
     let queries = vec![
-        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::All),
-        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::Distinct),
-        SubgraphQuery::nodes([14]).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::Distinct),
-        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::ReferenceOnly),
-        SubgraphQuery::path_offset(&path_b, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::Distinct),
+        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::All),
+        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::Distinct),
+        SubgraphQuery::nodes([14]).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::Distinct),
+        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::ReferenceOnly),
+        SubgraphQuery::path_offset(&path_b, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::Distinct),
+        SubgraphQuery::path_offset(&path_b, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::None),
     ];
     let gfas = vec![
         vec![
@@ -603,6 +606,16 @@ fn queries_and_gfas(cigar: bool) -> (Vec<SubgraphQuery>, Vec<Vec<String>>){
             String::from("L\t24\t+\t25\t+\t0M"),
             String::from("W\t_gbwt_ref\t0\tB\t1\t4\t>22>24>25\tWT:i:2"),
             format!("W\tunknown\t1\tB\t0\t3\t>22>24<23\tWT:i:1{}", if cigar { "\tCG:Z:3M" } else { "" }),
+        ],
+        vec![
+            String::from("H\tVN:Z:1.1"),
+            String::from("S\t22\tA"),
+            String::from("S\t23\tT"),
+            String::from("S\t24\tT"),
+            String::from("S\t25\tA"),
+            String::from("L\t22\t+\t24\t+\t0M"),
+            String::from("L\t23\t+\t24\t-\t0M"),
+            String::from("L\t24\t+\t25\t+\t0M"),
         ]
     ];
     (queries, gfas)
@@ -613,10 +626,10 @@ fn queries_and_jsons(cigar: bool) -> (Vec<SubgraphQuery>, Vec<String>){
     let path_a = FullPathName::generic("A");
     //let path_b = FullPathName::generic("B");
     let queries = vec![
-        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::All),
-        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::Distinct),
-        SubgraphQuery::nodes([14]).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::Distinct),
-        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_output(HaplotypeOutput::ReferenceOnly),
+        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::All),
+        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::Distinct),
+        SubgraphQuery::nodes([14]).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::Distinct),
+        SubgraphQuery::path_offset(&path_a, 2).with_context(1).with_snarls(SnarlOutput::None).with_haplotypes(HaplotypeOutput::ReferenceOnly),
     ];
 
     let mut nodes: Vec<JSONValue> = Vec::new();
@@ -1207,7 +1220,7 @@ fn gfa_output() {
             assert_eq!(lines.len(), truth.len() + name_headers.len(), "Wrong number of lines in GFA output for query {}", query);
             for (line_num, &line) in lines.iter().enumerate() {
                 if line_num == 0 {
-                    assert_eq!(line, lines[0], "Wrong GFA file header for query {}", query);
+                    assert_eq!(line, truth[0], "Wrong GFA file header for query {}", query);
                 } else if line_num <= name_headers.len() {
                     let header_line = &name_headers[line_num - 1];
                     assert_eq!(line, header_line, "Wrong GFA name header line {} for query {}", line_num, query);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -910,7 +910,7 @@ fn append_query_variants(
 ) {
     for context in [0, 30, 100] {
         for snarls in [SnarlOutput::None, SnarlOutput::Contained, SnarlOutput::Overlapping] {
-            for output in [HaplotypeOutput::All, HaplotypeOutput::Distinct, HaplotypeOutput::ReferenceOnly] {
+            for output in [HaplotypeOutput::All, HaplotypeOutput::Distinct, HaplotypeOutput::ReferenceOnly, HaplotypeOutput::None] {
                 if query.is_node_based() && output == HaplotypeOutput::ReferenceOnly {
                     // No reference path.
                     continue;
@@ -919,7 +919,7 @@ fn append_query_variants(
                     // Not implemented.
                     continue;
                 }
-                queries.push(query.clone().with_context(context).with_snarls(snarls).with_output(output));
+                queries.push(query.clone().with_context(context).with_snarls(snarls).with_haplotypes(output));
                 let mut args = args.to_vec();
                 args.push(String::from("--context"));
                 args.push(context.to_string());
@@ -939,6 +939,9 @@ fn append_query_variants(
                     },
                     HaplotypeOutput::ReferenceOnly => {
                         args.push(String::from("--reference-only"));
+                    },
+                    HaplotypeOutput::None => {
+                        args.push(String::from("--no-haplotypes"));
                     },
                 }
                 arg_lists.push(args);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -932,16 +932,19 @@ fn append_query_variants(
                         args.push(String::from("--extend-snarls"));
                     },
                 }
+                args.push(String::from("--haplotypes"));
                 match output {
-                    HaplotypeOutput::All => {},
+                    HaplotypeOutput::All => {
+                        args.push(String::from("all"));
+                    },
                     HaplotypeOutput::Distinct => {
-                        args.push(String::from("--distinct"));
+                        args.push(String::from("distinct"));
                     },
                     HaplotypeOutput::ReferenceOnly => {
-                        args.push(String::from("--reference-only"));
+                        args.push(String::from("reference-only"));
                     },
                     HaplotypeOutput::None => {
-                        args.push(String::from("--no-haplotypes"));
+                        args.push(String::from("none"));
                     },
                 }
                 arg_lists.push(args);
@@ -1164,14 +1167,21 @@ fn gbz_base_query_between() {
 fn run_gbz_gaf_base_query(
     temp_files: &mut TempFileHandler,
     graph_file: &PathBuf, gaf_base_file: &PathBuf,
-    query_args: &[String], alignment_output: Option<AlignmentOutput>
+    query_args: &[String], alignment_output: Option<AlignmentOutput>,
+    gaf_only: bool
 ) -> Vec<u8> {
     let mut query_args = query_args.to_vec();
     query_args.push(String::from("--gaf-base"));
     query_args.push(gaf_base_file.to_str().unwrap().to_string());
-    query_args.push(String::from("--gaf-output"));
-    let gaf_output_file = temp_files.new_file("gaf-base-output");
-    query_args.push(gaf_output_file.to_str().unwrap().to_string());
+    let gaf_output_file = if gaf_only {
+        query_args.push(String::from("--gaf-only"));
+        None
+    } else {
+        query_args.push(String::from("--gaf-output"));
+        let gaf_output_file = temp_files.new_file("gaf-base-output");
+        query_args.push(gaf_output_file.to_str().unwrap().to_string());
+        Some(gaf_output_file)
+    };
     match alignment_output {
         Some(output) => {
             query_args.push(String::from("--alignments"));
@@ -1182,9 +1192,11 @@ fn run_gbz_gaf_base_query(
 
     let output = run_gbz_base_query(graph_file, None, &query_args, None, false);
     assert!(output.status.success(), "gbz-base query with args {:?} failed with status: {}", query_args, output.status);
-    let gaf_data = fs::read(&gaf_output_file).expect("Failed to read GAF output file");
-
-    gaf_data
+    if let Some(gaf_output_file) = gaf_output_file {
+        fs::read(&gaf_output_file).expect("Failed to read GAF output file")
+    } else {
+        output.stdout
+    }
 }
 
 fn write_gaf(read_set: &ReadSet, subgraph: &Subgraph) -> Vec<u8> {
@@ -1248,13 +1260,19 @@ fn gbz_base_query_with_gaf_base() {
     for (query, args) in queries.iter().zip(arg_lists.iter()) {
         for alignment_output in [None, Some(AlignmentOutput::Overlapping), Some(AlignmentOutput::Clipped), Some(AlignmentOutput::Contained)] {
 
-            let binary_gbz_gaf = run_gbz_gaf_base_query(&mut temp_files, &graph_file, &gaf_base_file, args, alignment_output);
+            let binary_gbz_gaf = run_gbz_gaf_base_query(&mut temp_files, &graph_file, &gaf_base_file, args, alignment_output, false);
             let output = alignment_output.unwrap_or(AlignmentOutput::Clipped);
             let library_gbz_gaf = run_subgraph_query_with_gbz_gaf(&gbz, Some(&path_index), &gaf_base, &query, output);
             let gbz_gaf_query_ok = binary_gbz_gaf == library_gbz_gaf;
             assert!(gbz_gaf_query_ok, "Output mismatch for query {} with alignment output {}", query, output);
 
-            let binary_db_gaf = run_gbz_gaf_base_query(&mut temp_files, &gbz_base_file, &gaf_base_file, args, alignment_output);
+            if alignment_output.is_none() {
+                let gaf_only = run_gbz_gaf_base_query(&mut temp_files, &graph_file, &gaf_base_file, args, alignment_output, true);
+                let gaf_only_ok = gaf_only == library_gbz_gaf;
+                assert!(gaf_only_ok, "Output mismatch for query {} with --gaf-only", query);
+            }
+
+            let binary_db_gaf = run_gbz_gaf_base_query(&mut temp_files, &gbz_base_file, &gaf_base_file, args, alignment_output, false);
             let library_db_gaf = run_subgraph_query_with_db_gaf(&mut interface, &gaf_base, &query, output);
             let db_gaf_query_ok = binary_db_gaf == library_db_gaf;
             assert!(db_gaf_query_ok, "Output mismatch for query {} with alignment output {}", query, output);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -953,6 +953,7 @@ fn append_query_variants(
     }
 }
 
+// This does not generate between queries, because they only make sense with specific nodes.
 fn generate_queries(gfa_file: &PathBuf, include_variants: bool) -> (Vec<SubgraphQuery>, Vec<Vec<String>>) {
     const NUM_QUERIES: usize = 3;
 
@@ -1108,6 +1109,9 @@ fn gbz_base_query() {
     }
 }
 
+// Here we also test setting a safety limit.
+// We already know from unit tests that the limit will trigger with all kinds of queries,
+// so we don't need to repeat that here.
 #[test]
 fn gbz_base_query_between() {
     let mut temp_files = TempFileHandler::new();
@@ -1131,9 +1135,8 @@ fn gbz_base_query_between() {
         for limit in [None, Some(10), Some(100), Some(1000)] {
             let query = SubgraphQuery::between(
                 support::encode_node(start, Orientation::Forward),
-                support::encode_node(end, Orientation::Forward),
-                limit
-            );
+                support::encode_node(end, Orientation::Forward)
+            ).with_limit(limit);
             let mut args = vec![
                 String::from("--between"),
                 format!("{}:{}", start, end),


### PR DESCRIPTION
Improvements to subgraph queries and `gbz-base query`:

* New option for subgraph queries with no haplotypes in the output.
* Haplotype output selection in `gbz-base query` is now done with option `--haplotypes`.
* GAF-only output to stdout in `gbz-base query` with option `--gaf-only`.
* Safety limit for subgraph size can now be set in all queries, not just `--between`.

The safety limit applies to the size of the temporary subgraph. In path-based queries, the all nodes between the nearest sampled reference position and the query position are added to the subgraph. They will be removed later if they are not in the final subgraph. In such cases, the safety limit can be exceeded even if the final subgraph fits within the limit.